### PR TITLE
Fix check to find out if we are in mcp

### DIFF
--- a/src/minecraft/co/uk/flansmods/common/FlansMod.java
+++ b/src/minecraft/co/uk/flansmods/common/FlansMod.java
@@ -148,7 +148,7 @@ public class FlansMod
 		
 		try
 		{
-			Class.forName("net.minecraft.src.World");
+			Class.forName("net.minecraft.world.World");
 		}
 		catch(Exception e)
 		{


### PR DESCRIPTION
Minecraft Forge has changed the package structure of minecraft, the Class,forName check must accompany this change
