### PR TITLE
Fix: Texture Error at Trapezoids, ShapeBoxes etc.

### DIFF
--- a/src/minecraft/co/uk/flansmods/client/tmt/ModelRendererTurbo.java
+++ b/src/minecraft/co/uk/flansmods/client/tmt/ModelRendererTurbo.java
@@ -528,7 +528,7 @@ public class ModelRendererTurbo extends ModelRenderer
 				Math.abs((v3[2] - v7[2])/(v2[2]-v6[2]))	
 		};
 		
-		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d, qValues);
+		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d);
 	}
 
 	/**
@@ -659,7 +659,7 @@ public class ModelRendererTurbo extends ModelRenderer
 				Math.abs((v3[2] - v7[2])/(v2[2]-v6[2]))	
 		};
 		
-		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d, qValues);
+		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d);
 	}
 
 	/**
@@ -823,7 +823,7 @@ public class ModelRendererTurbo extends ModelRenderer
 				Math.abs((v3[2] - v7[2])/(v2[2]-v6[2]))	
 		};
 		
-		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d, qValues);
+		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d);
 	}
 
 	/** 
@@ -914,7 +914,7 @@ public class ModelRendererTurbo extends ModelRenderer
 				Math.abs((v3[2] - v7[2])/(v2[2]-v6[2]))	
 		};
 		
-		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d, qValues);
+		addRectShape(v, v1, v2, v3, v4, v5, v6, v7, w, h, d);
 	}
 
 


### PR DESCRIPTION
Seems the qValue calculation is not correct. This causes texture errors
when having a part which is getting smaller on one side or when using a
shader mod.
Switched back to normal texture rendering as before, the texture
tansformation is no not as good as it should be again.
