### PR TITLE
Adding forgotten sutff on the en_US.lang file

### DIFF
--- a/eclipse/Flan/WW2 Pack/assets/flansmod/lang/en_US.lang
+++ b/eclipse/Flan/WW2 Pack/assets/flansmod/lang/en_US.lang
@@ -139,3 +139,5 @@ item.trenchgun.name=Trenchgun
 item.trenchgunAmmo.name=Trenchgun Ammo
 item.flamethrower.name=Flamethrower
 item.flamethrowerAmmo.name=Flamethrower Ammo
+item.cobra.name=Huey Cobra
+item.mk4Rocket.name=Mk. 4 FFAR "Mighty Mouse" Rocket


### PR DESCRIPTION
well I think someone forgot the Huey Cobra and Mk. 4 FFAR "Mighty Mouse" Rocket on the .lang file so I added it
