### PR TITLE
Temporarily nerf modern tanks. (for real this time)

### DIFF
--- a/eclipse/Flan/Modern Weapons Pack/vehicles/Abrams.txt
+++ b/eclipse/Flan/Modern Weapons Pack/vehicles/Abrams.txt
@@ -63,9 +63,9 @@ AddRecipeParts rightTrack 1 catTrack
 //Dye colours are "black", "red", "green", "brown", "blue", "purple", "cyan", "silver", "gray", "pink", "lime", "yellow", "lightBlue", "magenta", "orange", "white"
 AddDye 10 gray
 //Health and collision
-SetupPart core 23000 -82 -1 -34 153 26 68
-SetupPart turret 18000 -59 25 -29 98 15 58
-SetupPart rightTrack 12000 -81 -10 -34 154 20 13
-SetupPart leftTrack 12000 -81 -10 21 154 21 13
+SetupPart core 1200 -82 -1 -34 153 26 68
+SetupPart turret 800 -59 25 -29 98 15 58
+SetupPart rightTrack 500 -81 -10 -34 154 20 13
+SetupPart leftTrack 500 -81 -10 21 154 21 13
 BulletDetection 7
 RotateWheels true

--- a/eclipse/Flan/Modern Weapons Pack/vehicles/ChallyIISimple.txt
+++ b/eclipse/Flan/Modern Weapons Pack/vehicles/ChallyIISimple.txt
@@ -64,10 +64,10 @@ AddRecipeParts rightTrack 1 catTrack
 //Dye colours are "black", "red", "green", "brown", "blue", "purple", "cyan", "silver", "gray", "pink", "lime", "yellow", "lightBlue", "magenta", "orange", "white"
 AddDye 10 gray
 //Health and collision
-SetupPart core 27500 -69 0 -33 137 23 66
-SetupPart rightTrack 15000 -69 -10 -33 136 10 12
-SetupPart leftTrack 15000 -69 -10 21 136 10 12
-SetupPart turret 18000 -48 23 -27 92 16 54
+SetupPart core 2000 -69 0 -33 137 23 66
+SetupPart rightTrack 500 -69 -10 -33 136 10 12
+SetupPart leftTrack 500 -69 -10 21 136 10 12
+SetupPart turret 1500 -48 23 -27 92 16 54
 BulletDetection 7
 
 RotateWheels true

--- a/eclipse/Flan/Modern Weapons Pack/vehicles/Leopard 2A6.txt
+++ b/eclipse/Flan/Modern Weapons Pack/vehicles/Leopard 2A6.txt
@@ -64,10 +64,10 @@ AddRecipeParts rightTrack 1 catTrack
 //Dye colours are "black", "red", "green", "brown", "blue", "purple", "cyan", "silver", "gray", "pink", "lime", "yellow", "lightBlue", "magenta", "orange", "white"
 AddDye 10 gray
 //Health and collision
-SetupPart core 24500 -78 -1 -36 149 22 72
-SetupPart leftTrack 10000 -68 -11 -32 133 21 11
-SetupPart rightTrack 10000 -68 -11 21 133 21 11
-SetupPart turret 15000 -60 21 -29 112 14 58
+SetupPart core 1600 -78 -1 -36 149 22 72
+SetupPart leftTrack 500 -68 -11 -32 133 21 11
+SetupPart rightTrack 500 -68 -11 21 133 21 11
+SetupPart turret 12000 -60 21 -29 112 14 58
 BulletDetection 7
 ModelScale 0.77
 

--- a/eclipse/Flan/Modern Weapons Pack/vehicles/T-90.txt
+++ b/eclipse/Flan/Modern Weapons Pack/vehicles/T-90.txt
@@ -60,8 +60,8 @@ AddRecipeParts rightTrack 1 catTrack
 //Dye colours are "black", "red", "green", "brown", "blue", "purple", "cyan", "silver", "gray", "pink", "lime", "yellow", "lightBlue", "magenta", "orange", "white"
 AddDye 10 green
 //Health and collision
-SetupPart core 800 -69 -4 -21 143 24 42
-SetupPart turret 200 -40 25 -32 85 11 64
-SetupPart rightTrack 250 -63 -14 -34 133 25 13
-SetupPart leftTrack 250 -63 -14 22 133 25 12
+SetupPart core 1500 -69 -4 -21 143 24 42
+SetupPart turret 900 -40 25 -32 85 11 64
+SetupPart rightTrack 500 -63 -14 -34 133 25 13
+SetupPart leftTrack 500 -63 -14 22 133 25 12
 BulletDetection 7


### PR DESCRIPTION
Health values were intended for use after an overhaul in weapon damaging. Currently these values are too high and would be considered gamebreaking. I will correct them back to their full state when they are ready.

