### PR TITLE
Fix for issiue #771

### DIFF
--- a/src/main/java/com/flansmod/common/FlansModExplosion.java
+++ b/src/main/java/com/flansmod/common/FlansModExplosion.java
@@ -33,6 +33,7 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
+import net.minecraftforge.event.world.ExplosionEvent;
 
 public class FlansModExplosion extends Explosion 
 {
@@ -191,13 +192,8 @@ public class FlansModExplosion extends Explosion
     /** Second part of the explosion (sound, particles, drop spawn) */
     public void doExplosionB(boolean p_77279_1_)
     {
-        this.world.playSoundEffect(this.x, this.y, this.z, "random.explode", 4.0F, (1.0F + (this.world.rand.nextFloat() - this.world.rand.nextFloat()) * 0.2F) * 0.7F);
 
-        if (this.isSmoking)
-        {
-            this.world.spawnParticle(EnumParticleTypes.EXPLOSION_HUGE, this.x, this.y, this.z, 1.0D, 0.0D, 0.0D, new int[0]);
-        }
-        else
+        if (!this.isSmoking)
         {
             this.world.spawnParticle(EnumParticleTypes.EXPLOSION_LARGE, this.x, this.y, this.z, 1.0D, 0.0D, 0.0D, new int[0]);
         }
@@ -207,12 +203,14 @@ public class FlansModExplosion extends Explosion
 
         if (this.isSmoking&&breaksBlocks)
         {
-            worldObj.createExplosion(detonator, x, y, z, radius, true);
+            this.world.createExplosion(detonator, x, y, z, radius, true);
         }
         
         else if (this.isSmoking)
         {
-            entity.attackEntityFrom(player == null || type == null ? DamageSource.setExplosionSource(this) : new EntityDamageSourceGun(type.shortName, explosive, detonator, type, false), (float)((int)((d10 * d10 + d10) / 2.0D * 8.0D * (double)f3 + 1.0D)));
+        	Explosion expl=new Explosion(world, explosive, x, y, z, radius, true, true);
+        	expl.doExplosionA();
+        	this.world.playSoundEffect(this.x, this.y, this.z, "random.explode", 4.0F, (1.0F + (this.world.rand.nextFloat() - this.world.rand.nextFloat()) * 0.2F) * 0.7F);
         }
 
         if (this.isFlaming)

--- a/src/main/java/com/flansmod/common/guns/EntityBullet.java
+++ b/src/main/java/com/flansmod/common/guns/EntityBullet.java
@@ -23,6 +23,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntityDamageSourceIndirect;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
@@ -86,6 +87,9 @@ public class EntityBullet extends EntityShootable implements IEntityAdditionalSp
 	public float penetratingPower;
 	
 	private float yOffset;
+	
+	/** For explosion offset purposes to fix explosion inside of the hit block*/
+	private EnumFacing sideHit;
 	
 	@SideOnly(Side.CLIENT)
 	private boolean playedFlybySound;
@@ -380,11 +384,11 @@ public class EntityBullet extends EntityShootable implements IEntityAdditionalSp
 		Vec3 posVec = new Vec3(posX, posY, posZ);
 		Vec3 nextPosVec = new Vec3(posX + motionX, posY + motionY, posZ + motionZ);
 		MovingObjectPosition hit = worldObj.rayTraceBlocks(posVec, nextPosVec, false, true, true);
-		
 		posVec = new Vec3(posX, posY, posZ);
 		
 		if(hit != null)
 		{
+			sideHit = hit.sideHit;
 			//Calculate the lambda value of the intercept
 			Vec3 hitVec = posVec.subtract(hit.hitVec);
 			float lambda = 1;
@@ -665,6 +669,45 @@ public class EntityBullet extends EntityShootable implements IEntityAdditionalSp
 			return;
 		if(type.explosionRadius > 0)
 		{
+			if(sideHit!=null)
+			switch (sideHit)
+			{
+			case DOWN : {
+				//hit from below
+				posY = posY-0.0001;
+	        	if(!worldObj.getBlockState(new BlockPos(posX, posY, posZ)).getBlock().isSolidFullCube())posY = posY-1.0;
+				break;
+			}
+			
+			case NORTH : {
+				//hit north facing side
+				posZ = posZ-0.0001;
+	        	if(!worldObj.getBlockState(new BlockPos(posX, posY, posZ)).getBlock().isSolidFullCube())posZ = posZ-1.0;
+				break;
+			}
+			
+			case WEST : {
+				//hit west facing side
+				posX = posX-0.0001;
+	        	if(!worldObj.getBlockState(new BlockPos(posX, posY, posZ)).getBlock().isSolidFullCube())posX = posX-1.0;
+				break;
+			}
+			case UP : {
+				//hit from above
+	        	if(!worldObj.getBlockState(new BlockPos(posX, posY, posZ)).getBlock().isSolidFullCube())posY = posY+1.0;
+				break;
+			}
+			case SOUTH : {
+				//hit south facing side
+	        	if(!worldObj.getBlockState(new BlockPos(posX, posY, posZ)).getBlock().isSolidFullCube())posX = posX+1.0;
+				break;
+			}
+			case EAST : {
+				//hit east facing side
+	        	if(!worldObj.getBlockState(new BlockPos(posX, posY, posZ)).getBlock().isSolidFullCube())posZ = posZ+1.0;
+				break;
+			}
+			}
 	        if((owner instanceof EntityPlayer))
 	        	new FlansModExplosion(worldObj, this, (EntityPlayer)owner, type, posX, posY, posZ, type.explosionRadius, type.fireRadius > 0, type.flak > 0, type.explosionBreaksBlocks);
 	        else 


### PR DESCRIPTION
Upon request by godgodgodgo, here is attempt 3 to fix said issiue together with slight compatibility improvements.

if grenades or explosive bullets impact a non-solid block, the explosion gets offset 1 block into the direction the bullet hit the block from. this does however not work as requested if the said non-solid block is a chest and you hit it from above with no water directly above. Fixing that issue would cost a lot of time and computing when bullets hit chests in said way, so that is ignored for now.