### PR TITLE
Short name fixes for aircraft/weapon box guns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,20 @@ Thumbs.db
 
 # Flan's Mod
 !run/Flan/
+run/Flan/Parts Pack/assets/flansmod/.DS_Store
+
+run/Flan/.DS_Store
+
+run/Flan/Modern Weapons Pack/.DS_Store
+
+run/Flan/Parts Pack/.DS_Store
+
+run/Flan/Parts Pack/assets/.DS_Store
+
+run/Flan/Parts Pack/assets/flansmod/textures/.DS_Store
+
+run/Flan/Utility Pack/.DS_Store
+
+run/Flan/WW2 Pack/.DS_Store
+
+run/Flan/WW2 Pack/boxes/.DS_Store

--- a/run/Flan/WW2 Pack/boxes/British.txt
+++ b/run/Flan/WW2 Pack/boxes/British.txt
@@ -35,4 +35,5 @@ AddGun PIAT 24 ingotIron
 AddAmmo PIATAmmo 5 ingotIron 3 gunpowder
 AddGun boforsAmmo 1 ingotIron 2 gunpowder
 AddGun millsBomb 2 ingotIron 2 gunpowder
-AddGun British2pdrAPShell 3 ingotIron 3 gunpowder
+AddGun 2Pdr 9 ingotIron
+AddAmmo British2pdrAPShell 3 ingotIron 3 gunpowder

--- a/run/Flan/WW2 Pack/boxes/German.txt
+++ b/run/Flan/WW2 Pack/boxes/German.txt
@@ -27,11 +27,11 @@ AddAmmo lugerAmmo 2 ingotIron 1 gunpowder
 SetPage Page 2
 AddGun mp40 10 ingotIron
 AddAmmo mp40Ammo 3 ingotIron 1 gunpowder
-AddGun STG44 20 ingotIron 4 log
-AddAmmo STG44Ammo 4 ingotIron 1 gunpowder
-AddGun MG42 25 ingotIron 5 log
-AddAmmo MG42Ammo50 5 ingotIron 4 gunpowder
-AddAltAmmo MG42Ammo250 20 ingotIron 20 gunpowder
+AddGun mp44 20 ingotIron 4 log
+AddAmmo mp44Ammo 4 ingotIron 1 gunpowder
+AddGun mg42 25 ingotIron 5 log
+AddAmmo mg42Ammo50 5 ingotIron 4 gunpowder
+AddAltAmmo mg42Ammo250 20 ingotIron 20 gunpowder
 AddGun MG151 28 ingotIron
 AddAmmo MG151Ammo 4 ingotIron 8 gunpowder
 AddGun stielhandgranate 2 ingotIron 2 gunpowder

--- a/run/Flan/WW2 Pack/boxes/Japanese.txt
+++ b/run/Flan/WW2 Pack/boxes/Japanese.txt
@@ -13,8 +13,6 @@ III
 //The names of the items / blocks are those in the code, with some exceptions such as ingotIron (ingotingotIron) and gunpowder (sulphur)
 //And with parts from this mod, they are the shortName of the item
 //Guns cannot yet have multiple ammo types in the same slot. For now, just list them under two seperate guns that are the same
-//NumGuns must come before all the addGun lines and must be correct.
-NumGuns 8
 SetPage Page 1
 AddGun type38 10 ingotIron 10 log
 AddAmmo type38Ammo 2 ingotIron 1 gunpowder

--- a/run/Flan/WW2 Pack/planes/BF109.txt
+++ b/run/Flan/WW2 Pack/planes/BF109.txt
@@ -49,8 +49,8 @@ AlternateSecondary False
 ModePrimary FullAuto
 ModeSecondary FullAuto
 //Add shoot origins. These are the points on your vehicle from which bullets / missiles / shells / bombs appear
-ShootPointPrimary 69 39 6 nose MG42
-ShootPointPrimary 69 39 -6 nose MG42
+ShootPointPrimary 69 39 6 nose mg42
+ShootPointPrimary 69 39 -6 nose mg42
 ShootPointPrimary 94 30 0 nose MG151
 AlternatePrimary True
 AlternateSecondary False

--- a/run/Flan/WW2 Pack/planes/Camel.txt
+++ b/run/Flan/WW2 Pack/planes/Camel.txt
@@ -49,8 +49,8 @@ AlternateSecondary False
 ModePrimary FullAuto
 ModeSecondary FullAuto
 //Add shoot origins. These are the points on your vehicle from which bullets / missiles / shells / bombs appear
-ShootPointPrimary 30 3 5 nose browning30Cal
-ShootPointPrimary 30 3 -5 nose browning30Cal
+ShootPointPrimary 30 3 5 nose browning
+ShootPointPrimary 30 3 -5 nose browning
 DamageModifierPrimary 50
 // ------------------------------------------------------ Inventory ------------------------------------------------------
 CargoSlots 8

--- a/run/Flan/WW2 Pack/planes/Fokker.txt
+++ b/run/Flan/WW2 Pack/planes/Fokker.txt
@@ -49,8 +49,8 @@ AlternateSecondary False
 ModePrimary FullAuto
 ModeSecondary FullAuto
 //Add shoot origins. These are the points on your vehicle from which bullets / missiles / shells / bombs appear
-ShootPointPrimary 30 8 5 nose MG42
-ShootPointPrimary 30 8 -5 nose MG42
+ShootPointPrimary 30 8 5 nose mg42
+ShootPointPrimary 30 8 -5 nose mg42
 DamageModifierPrimary 50
 // ------------------------------------------------------ Inventory ------------------------------------------------------
 CargoSlots 8

--- a/run/Flan/WW2 Pack/planes/Spitfire.txt
+++ b/run/Flan/WW2 Pack/planes/Spitfire.txt
@@ -49,8 +49,8 @@ AlternateSecondary False
 ModePrimary FullAuto
 ModeSecondary FullAuto
 //Add shoot origins. These are the points on your vehicle from which bullets / missiles / shells / bombs appear
-ShootPointPrimary 40 -4 44 rightWing browning30Cal
-ShootPointPrimary 40 -4 -44 leftWing browning30Cal
+ShootPointPrimary 40 -4 44 rightWing browning
+ShootPointPrimary 40 -4 -44 leftWing browning
 ShootPointSecondary -30 -12 0
 DamageModifierPrimary 50
 // ------------------------------------------------------ Inventory ------------------------------------------------------

--- a/run/Flan/WW2 Pack/vehicles/S100.txt
+++ b/run/Flan/WW2 Pack/vehicles/S100.txt
@@ -35,7 +35,7 @@ ShellSlots 2
 BarrelPosition 250 0 -20
 BarrelPosition 250 0 20
 //Driver and passenger positions
-Driver 120 47 -8 0 0 0 0
+Driver 120 47 -8 -360 360 -10 45
 RotatedDriverOffset 0 0 0
 Passengers 3
 Passenger 1 -22 36 -1 core -360 360 0 25 Flak38 PassengerGun1


### PR DESCRIPTION
Some of the planes (especially older ones) have 'empty' gun slots because they
are using the wrong names and thus can’t fire at all. This fixes that
by using the correct short names. The Japanese box also has a extra
‘default’ page which is removed by removing 2 lines in the text file.

Specifically:
'MG42' should be 'mg42'
'browning30Cal' should be 'browning'
'STG44' should be 'mp44'

This affects the BF109, Sopwith Camel, Supermarine Spitfire and Fokker Dr.1 Triplane. These changes will fix issue #786 and make the aircraft drop their components correctly now.

The Japanese weapon box has a extra 'default' page listed. Removing the line 'newGuns' fixes it.

Other fixes of mine include unlocking the S100 driver's FOV and adding the 2-Pdr recipe to the British Weapons Box (It doesn't seem to be craft-able otherwise)