### PR TITLE
Making EntityDebugVector a full functional Entity

### DIFF
--- a/src/main/java/com/flansmod/client/debug/EntityDebugColor.java
+++ b/src/main/java/com/flansmod/client/debug/EntityDebugColor.java
@@ -1,0 +1,107 @@
+package com.flansmod.client.debug;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.datasync.DataParameter;
+import net.minecraft.network.datasync.DataSerializers;
+import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.world.World;
+
+/**
+ * Class Skeleton for DebugEntites which use a color
+ */
+public abstract class EntityDebugColor extends Entity {
+
+    private static final DataParameter<Float> COLOR_RED = EntityDataManager.<Float>createKey(EntityDebugVector.class, DataSerializers.FLOAT);
+    private static final DataParameter<Float> COLOR_GREEN = EntityDataManager.<Float>createKey(EntityDebugVector.class, DataSerializers.FLOAT);
+    private static final DataParameter<Float> COLOR_BLUE = EntityDataManager.<Float>createKey(EntityDebugVector.class, DataSerializers.FLOAT);
+	
+	/**
+	 * @param w World for Entity Constructor
+	 */
+	public EntityDebugColor(World w) {
+		super(w);
+	}
+
+	@Override
+	protected void entityInit()
+	{
+        this.dataManager.register(COLOR_RED, Float.valueOf(1));
+        this.dataManager.register(COLOR_GREEN, 1F);
+        this.dataManager.register(COLOR_BLUE, 1F);
+	}
+	
+	@Override
+	protected void readEntityFromNBT(NBTTagCompound nbttagcompound)
+	{
+		this.setColorRed(nbttagcompound.getFloat("color_red"));
+		this.setColorGreen(nbttagcompound.getFloat("color_green"));
+		this.setColorBlue(nbttagcompound.getFloat("color_blue"));
+	}
+	
+	@Override
+	protected void writeEntityToNBT(NBTTagCompound nbttagcompound)
+	{
+		nbttagcompound.setFloat("color_red", getColorRed());
+		nbttagcompound.setFloat("color_green", getColorGreen());
+		nbttagcompound.setFloat("color_blue", getColorBlue());
+	}
+	
+	/**
+	 * Color values range from 0 (Nonexistent) to 1 (Fully Visible)
+	 * @param red Red color value
+	 */
+	public void setColorRed(Float red) {
+		this.dataManager.set(COLOR_RED, Float.valueOf(red));
+	}
+	/**
+	 * Color values range from 0 (Nonexistent) to 1 (Fully Visible)
+	 * @return Red color value
+	 */
+	public Float getColorRed() {
+		return this.dataManager.get(COLOR_RED);
+	}
+	
+	/**
+	 * Color values range from 0 (Nonexistent) to 1 (Fully Visible)
+	 * @param green Green color value
+	 */
+	public void setColorGreen(Float green) {
+		this.dataManager.set(COLOR_GREEN, green);
+	}
+	/**
+	 * Color values range from 0 (Nonexistent) to 1 (Fully Visible)
+	 * @return Green color value
+	 */
+	public Float getColorGreen() {
+		return dataManager.get(COLOR_GREEN);
+	}
+	
+	/**
+	 * Color values range from 0 (Nonexistend) to 1 (Fully Visible)
+	 * @param blue Blue color value
+	 */
+	public void setColorBlue(Float blue) {
+		dataManager.set(COLOR_BLUE, blue);
+	}
+	/**
+	 * Color values range from 0 (Nonexistent) to 1 (Fully Visible)
+	 * @return Blue color value
+	 */
+	public Float getColorBlue() {
+		return dataManager.get(COLOR_BLUE);
+	}
+	
+	/**
+	 * Combined Setter for all three color values
+	 * Color values range from 0 (Nonexistent) to 1 (Fully Visible)
+	 * @param red	Red color value
+	 * @param green	Green color value
+	 * @param blue	Blue color value
+	 */
+	public void setColor(Float red, Float green, Float blue) {
+		setColorRed(red);
+		setColorGreen(green);
+		setColorBlue(blue);
+	}
+}

--- a/src/main/java/com/flansmod/client/debug/EntityDebugVector.java
+++ b/src/main/java/com/flansmod/client/debug/EntityDebugVector.java
@@ -1,40 +1,63 @@
 package com.flansmod.client.debug;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.network.datasync.DataParameter;
+import net.minecraft.network.datasync.DataSerializers;
+import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.world.World;
 
 import com.flansmod.common.vector.Vector3f;
 
-public class EntityDebugVector extends Entity
+/**
+ * Entity for debugging purposes. On the Client side a line (Vector) between the Position of the Entity and its Pointing Location is rendered
+ */
+public class EntityDebugVector extends EntityDebugColor
 {
-	public Vector3f vector;
-	public int life;
-	public float red = 1F, green = 1F, blue = 1F;
 	
+    private static final DataParameter<Float> POINTING_X = EntityDataManager.<Float>createKey(EntityDebugVector.class, DataSerializers.FLOAT);
+    private static final DataParameter<Float> POINTING_Y = EntityDataManager.<Float>createKey(EntityDebugVector.class, DataSerializers.FLOAT);
+    private static final DataParameter<Float> POINTING_Z = EntityDataManager.<Float>createKey(EntityDebugVector.class, DataSerializers.FLOAT);
+	
+	public int life = 1000;
+	
+	/**
+	 * @param w World for Entity Constructor
+	 */
 	public EntityDebugVector(World w)
 	{
 		super(w);
+		setSize(0.25F, 0.25F);
 	}
 	
+	/**
+	 * Spawns an EntityDebug Vector
+	 * 
+	 * @param w World for Entity Constructor
+	 * @param u Position where the Vector starts
+	 * @param v Position where the Vector ends
+	 * @param i Lifetime given in ticks
+	 * @param r Red Color Value
+	 * @param g Green Color Value
+	 * @param b Blue Color Value
+	 */
 	public EntityDebugVector(World w, Vector3f u, Vector3f v, int i, float r, float g, float b)
 	{
-		super(w);
+		this(w);
 		setPosition(u.x, u.y, u.z);
-		vector = v;
+		setPointing(v.x, v.y, v.z);
+		setColor(r, g, b);
 		life = i;
-		red = r;
-		green = g;
-		blue = b;
 	}
 	
+	/**
+	 * @param w World for Entity Constructor
+	 * @param u Position where the Vector starts
+	 * @param v Position where the Vector ends
+	 * @param i Lifetime given in ticks
+	 */
 	public EntityDebugVector(World w, Vector3f u, Vector3f v, int i)
 	{
-		super(w);
-		setPosition(u.x, u.y, u.z);
-		vector = v;
-		life = i;
+		this(w, u, v, i, 1F, 1F, 1F);
 	}
 	
 	@Override
@@ -45,28 +68,83 @@ public class EntityDebugVector extends Entity
 			setDead();
 	}
 	
-	@Override
-	public AxisAlignedBB getCollisionBoundingBox()
-	{
-		return null;
-	}
-	
 	
 	@Override
 	protected void entityInit()
 	{
-		
+		super.entityInit();
+		this.dataManager.register(POINTING_X, 1F);
+		this.dataManager.register(POINTING_Y, 1F);
+		this.dataManager.register(POINTING_Z, 1F);
 	}
 	
 	@Override
 	protected void readEntityFromNBT(NBTTagCompound nbttagcompound)
 	{
-		
+		super.readEntityFromNBT(nbttagcompound);
+		this.dataManager.set(POINTING_X, nbttagcompound.getFloat("pointing_x"));
+		this.dataManager.set(POINTING_Y, nbttagcompound.getFloat("pointing_y"));
+		this.dataManager.set(POINTING_Z, nbttagcompound.getFloat("pointing_z"));
 	}
 	
 	@Override
 	protected void writeEntityToNBT(NBTTagCompound nbttagcompound)
 	{
-	
+		super.writeEntityToNBT(nbttagcompound);
+		nbttagcompound.setFloat("pointing_x", getPointingX());
+		nbttagcompound.setFloat("pointing_y", getPointingY());
+		nbttagcompound.setFloat("pointing_z", getPointingZ());
 	}
+	
+	/**
+	 * @param x The X value of the Position the Vector points to (Relative to Entity Position)
+	 */
+	public void setPointingX(Float x) {
+		dataManager.set(POINTING_X, x);
+	}
+	/**
+	 * @return The X value of the Position the Vector points to (Relative to Entity Position)
+	 */
+	public Float getPointingX() {
+		return dataManager.get(POINTING_X);
+	}
+	
+	/**
+	 * @param y The Y value of the Position the Vector points to (Relative to Entity Position)
+	 */
+	public void setPointingY(Float y) {
+		dataManager.set(POINTING_Y, y);
+	}
+	/**
+	 * @return The Y value of the Position the Vector points to (Relative to Entity Position)
+	 */
+	public Float getPointingY() {
+		return dataManager.get(POINTING_Y);
+	}
+	
+	/**
+	 * @param z The Z value of the Position the Vector points to (Relative to Entity Position)
+	 */
+	public void setPointingZ(Float z) {
+		dataManager.set(POINTING_Z, z);
+	}
+	/**
+	 * @return The Z value of the Position the Vector points to (Relative to Entity Position)
+	 */
+	public Float getPointingZ() {
+		return dataManager.get(POINTING_Z);
+	}
+	
+	/**
+	 * All Parameters are relative to the Postion of the Entity.
+	 * These 3 Parameters describe the location of the Position the Vector points to.
+	 * @param x The X Coordinate
+	 * @param y The Y Coordinate
+	 * @param z The Z Coordinate
+	 */
+	public void setPointing(Float x, Float y, Float z) {
+		setPointingX(x);
+		setPointingY(y);
+		setPointingZ(z);
+		}
 }

--- a/src/main/java/com/flansmod/client/debug/RenderDebugVector.java
+++ b/src/main/java/com/flansmod/client/debug/RenderDebugVector.java
@@ -2,12 +2,12 @@ package com.flansmod.client.debug;
 
 import org.lwjgl.opengl.GL11;
 
+import com.flansmod.common.FlansMod;
+
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.client.registry.IRenderFactory;
-
-import com.flansmod.common.FlansMod;
 
 public class RenderDebugVector extends Render<EntityDebugVector>
 {
@@ -17,22 +17,23 @@ public class RenderDebugVector extends Render<EntityDebugVector>
 		super(renderManager);
 	}
 	
+	int i = 0;
+	
 	@Override
 	public void doRender(EntityDebugVector entity, double d0, double d1, double d2, float f, float f1)
 	{
 		if(!FlansMod.DEBUG)
 			return;
-		EntityDebugVector ent = entity;
 		
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 		GL11.glDisable(GL11.GL_DEPTH_TEST);
-		GL11.glColor3f(ent.red, ent.green, ent.blue);
+		GL11.glColor3f(entity.getColorRed(), entity.getColorGreen(), entity.getColorBlue());
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float)d0, (float)d1, (float)d2);
 		GL11.glLineWidth(5F);
 		GL11.glBegin(GL11.GL_LINE_STRIP);
 		GL11.glVertex3f(0F, 0F, 0F);
-		GL11.glVertex3f(ent.vector.x, ent.vector.y, ent.vector.z);
+		GL11.glVertex3f(entity.getPointingX(), entity.getPointingY(), entity.getPointingZ());
 		GL11.glEnd();
 		GL11.glPopMatrix();
 		GL11.glEnable(GL11.GL_TEXTURE_2D);

--- a/src/main/java/com/flansmod/common/FlansMod.java
+++ b/src/main/java/com/flansmod/common/FlansMod.java
@@ -57,6 +57,7 @@ import net.minecraftforge.fml.common.registry.EntityEntry;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
+import com.flansmod.client.debug.EntityDebugVector;
 import com.flansmod.common.driveables.EntityPlane;
 import com.flansmod.common.driveables.EntitySeat;
 import com.flansmod.common.driveables.EntityVehicle;
@@ -371,7 +372,7 @@ public class FlansMod
 		log.info("Registering Entities");
 		
 		event.getRegistry().register(new EntityEntry(EntityFlagpole.class, "Flagpole").setRegistryName("Flagpole"));
-		event.getRegistry().register(new EntityEntry(EntityFlag.class, "Flag").setRegistryName("Flag"));
+		event.getRegistry().register(new EntityEntry(EntityFlag.class, "flag").setRegistryName("flag"));
 		event.getRegistry().register(new EntityEntry(EntityTeamItem.class, "TeamsItem").setRegistryName("TeamsItem"));
 		event.getRegistry().register(new EntityEntry(EntityGunItem.class, "GunItem").setRegistryName("GunItem"));
 		event.getRegistry().register(new EntityEntry(EntityItemCustomRender.class, "CustomItem").setRegistryName("CustomItem"));
@@ -385,13 +386,14 @@ public class FlansMod
 		event.getRegistry().register(new EntityEntry(EntityGrenade.class, "Grenade").setRegistryName("Grenade"));
 		event.getRegistry().register(new EntityEntry(EntityMG.class, "MG").setRegistryName("MG"));
 		event.getRegistry().register(new EntityEntry(EntityAAGun.class, "AAGun").setRegistryName("AAGun"));
+		event.getRegistry().register(new EntityEntry(EntityDebugVector.class, "DebugVector").setRegistryName("DebugVector"));
 		
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:CustomItem"), EntityItemCustomRender.class, "CustomItem", 89, this, 100, 20, true);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Plane"), EntityPlane.class, "Plane", 90, this, 250, 3, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:MG"), EntityMG.class, "MG", 91, this, 40, 5, true);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:AAGun"), EntityAAGun.class, "AAGun", 92, this, 40, 500, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Flagpole"), EntityFlagpole.class, "Flagpole", 93, this, 40, 5, true);
-		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Flag"), EntityFlag.class, "Flag", 94, this, 40, 5, true);
+		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:flag"), EntityFlag.class, "flag", 94, this, 40, 5, true);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Vehicle"), EntityVehicle.class, "Vehicle", 95, this, 250, 10, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Bullet"), EntityBullet.class, "Bullet", 96, this, 40, 100, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:TeamsItem"), EntityTeamItem.class, "TeamsItem", 97, this, 100, 10000, true);
@@ -401,6 +403,7 @@ public class FlansMod
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Parachute"), EntityParachute.class, "Parachute", 101, this, 40, 20, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Mecha"), EntityMecha.class, "Mecha", 102, this, 250, 20, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Wheel"), EntityWheel.class, "Wheel", 103, this, 250, 20, false);
+		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:DebugVector"), EntityDebugVector.class, "DebugVector", 104, this, 250, 20, false);
 	}
 	
 	@EventHandler

--- a/src/main/java/com/flansmod/common/FlansMod.java
+++ b/src/main/java/com/flansmod/common/FlansMod.java
@@ -372,7 +372,7 @@ public class FlansMod
 		log.info("Registering Entities");
 		
 		event.getRegistry().register(new EntityEntry(EntityFlagpole.class, "Flagpole").setRegistryName("Flagpole"));
-		event.getRegistry().register(new EntityEntry(EntityFlag.class, "flag").setRegistryName("flag"));
+		event.getRegistry().register(new EntityEntry(EntityFlag.class, "Flag").setRegistryName("Flag"));
 		event.getRegistry().register(new EntityEntry(EntityTeamItem.class, "TeamsItem").setRegistryName("TeamsItem"));
 		event.getRegistry().register(new EntityEntry(EntityGunItem.class, "GunItem").setRegistryName("GunItem"));
 		event.getRegistry().register(new EntityEntry(EntityItemCustomRender.class, "CustomItem").setRegistryName("CustomItem"));
@@ -393,7 +393,7 @@ public class FlansMod
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:MG"), EntityMG.class, "MG", 91, this, 40, 5, true);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:AAGun"), EntityAAGun.class, "AAGun", 92, this, 40, 500, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Flagpole"), EntityFlagpole.class, "Flagpole", 93, this, 40, 5, true);
-		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:flag"), EntityFlag.class, "flag", 94, this, 40, 5, true);
+		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Flag"), EntityFlag.class, "Flag", 94, this, 40, 5, true);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Vehicle"), EntityVehicle.class, "Vehicle", 95, this, 250, 10, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:Bullet"), EntityBullet.class, "Bullet", 96, this, 40, 100, false);
 		EntityRegistry.registerModEntity(new ResourceLocation("flansmod:TeamsItem"), EntityTeamItem.class, "TeamsItem", 97, this, 100, 10000, true);


### PR DESCRIPTION
The Debug Entites are currently only partially implemented, which causes a series of problems. For example all EntityDebugVector spawned by the Server are not displayed on the client side, which removes the possibility of displaying the ray traces processed by the Server

In this Pull Request i fully implemented the EntityDebugVector and would like to hear some feedback as i want to implement the other DebugEntities, too.