### PR TITLE
Refactoring OpenGL API access

### DIFF
--- a/src/main/java/com/flansmod/apocalypse/client/ClientProxyApocalypse.java
+++ b/src/main/java/com/flansmod/apocalypse/client/ClientProxyApocalypse.java
@@ -2,12 +2,18 @@ package com.flansmod.apocalypse.client;
 
 import org.lwjgl.opengl.GL11;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
@@ -87,7 +93,7 @@ public class ClientProxyApocalypse extends CommonProxyApocalypse
 	@SubscribeEvent
 	public void registerModels(ModelRegistryEvent event)
 	{
-		/*
+		
 		Item item = Item.getItemFromBlock(FlansModApocalypse.blockSulphuricAcid);
 		ModelBakery.registerItemVariants(item);
 		final ModelResourceLocation modelResourceLocation = new ModelResourceLocation(FLUID_MODEL_PATH, FlansModApocalypse.sulphuricAcid.getName());
@@ -106,7 +112,7 @@ public class ClientProxyApocalypse extends CommonProxyApocalypse
 				return modelResourceLocation;
 			}
 		});
-		*/
+		
 		
 		ModelLoader.setCustomModelResourceLocation(FlansModApocalypse.itemBlockLabStone, 0, new ModelResourceLocation("flansmodapocalypse:itemblocklabstone", "inventory"));
 		ModelLoader.registerItemVariants(FlansModApocalypse.itemBlockLabStone, new ResourceLocation("flansmodapocalypse:itemblocklabstone"));
@@ -173,13 +179,13 @@ public class ClientProxyApocalypse extends CommonProxyApocalypse
 					if(mc.player.getDistanceSq(nuke) < scale * scale)
 					{
 						FlansModClient.minecraft.entityRenderer.setupOverlayRendering();
-						GL11.glEnable(3042 /* GL_BLEND */);
-						GL11.glDisable(2929 /* GL_DEPTH_TEST */);
-						GL11.glDisable(GL11.GL_TEXTURE_2D);
+						GlStateManager.enableBlend();
+						GL11.glDisable(GL11.GL_DEPTH_TEST);
+						GlStateManager.disableTexture2D();
 						GL11.glDepthMask(false);
 						GL11.glBlendFunc(770, 771);
-						GL11.glColor4f(1F, 1F, 1F, alpha);
-						GL11.glDisable(3008 /* GL_ALPHA_TEST */);
+						GlStateManager.color(1F, 1F, 1F, alpha);
+						GL11.glDisable(GL11.GL_ALPHA_TEST);
 						
 						WorldRenderer worldrenderer = FlansModClient.getWorldRenderer();
 						worldrenderer.startDrawingQuads();
@@ -189,10 +195,10 @@ public class ClientProxyApocalypse extends CommonProxyApocalypse
 						worldrenderer.addVertexWithUV(i / 2 - 2 * j, 0.0D, -90D, 0.0D, 0.0D);
 						worldrenderer.draw();
 						GL11.glDepthMask(true);
-						GL11.glEnable(2929 /* GL_DEPTH_TEST */);
-						GL11.glEnable(3008 /* GL_ALPHA_TEST */);
-						GL11.glEnable(GL11.GL_TEXTURE_2D);
-						GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+						GL11.glEnable(GL11.GL_DEPTH_TEST);
+						GL11.glEnable(GL11.GL_ALPHA_TEST);
+						GlStateManager.enableTexture2D();
+						GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 					}
 				}
 			}

--- a/src/main/java/com/flansmod/apocalypse/client/ClientProxyApocalypse.java
+++ b/src/main/java/com/flansmod/apocalypse/client/ClientProxyApocalypse.java
@@ -2,18 +2,13 @@ package com.flansmod.apocalypse.client;
 
 import org.lwjgl.opengl.GL11;
 
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
@@ -93,7 +88,7 @@ public class ClientProxyApocalypse extends CommonProxyApocalypse
 	@SubscribeEvent
 	public void registerModels(ModelRegistryEvent event)
 	{
-		
+		/*
 		Item item = Item.getItemFromBlock(FlansModApocalypse.blockSulphuricAcid);
 		ModelBakery.registerItemVariants(item);
 		final ModelResourceLocation modelResourceLocation = new ModelResourceLocation(FLUID_MODEL_PATH, FlansModApocalypse.sulphuricAcid.getName());
@@ -112,7 +107,7 @@ public class ClientProxyApocalypse extends CommonProxyApocalypse
 				return modelResourceLocation;
 			}
 		});
-		
+		*/
 		
 		ModelLoader.setCustomModelResourceLocation(FlansModApocalypse.itemBlockLabStone, 0, new ModelResourceLocation("flansmodapocalypse:itemblocklabstone", "inventory"));
 		ModelLoader.registerItemVariants(FlansModApocalypse.itemBlockLabStone, new ResourceLocation("flansmodapocalypse:itemblocklabstone"));

--- a/src/main/java/com/flansmod/apocalypse/client/model/RenderNukeDrop.java
+++ b/src/main/java/com/flansmod/apocalypse/client/model/RenderNukeDrop.java
@@ -1,7 +1,5 @@
 package com.flansmod.apocalypse.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -102,16 +100,16 @@ public class RenderNukeDrop extends Render<EntityNukeDrop>
 		//frustrum.setPosition(x, y, z);
 		
 		//Push
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		//Setup lighting
 		Minecraft.getMinecraft().entityRenderer.enableLightmap();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glDisable(GL11.GL_BLEND);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.enableLighting();
+		GlStateManager.disableBlend();
 		
 		RenderHelper.enableStandardItemLighting();
 		
-		GL11.glTranslatef(-(float)x, -(float)y, -(float)z);
+		GlStateManager.translate(-(float)x, -(float)y, -(float)z);
 		for(Object entity : world.loadedEntityList)
 		{
 			if(entity instanceof EntityNukeDrop)
@@ -137,9 +135,9 @@ public class RenderNukeDrop extends Render<EntityNukeDrop>
 		
 		//Reset Lighting
 		Minecraft.getMinecraft().entityRenderer.disableLightmap();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		GL11.glDisable(GL11.GL_LIGHTING);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.disableLighting();
 		//Pop
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 }

--- a/src/main/java/com/flansmod/client/ClientProxy.java
+++ b/src/main/java/com/flansmod/client/ClientProxy.java
@@ -13,7 +13,6 @@ import org.lwjgl.input.Mouse;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
@@ -273,8 +272,6 @@ public class ClientProxy extends CommonProxy
 	public void registerRenderers()
 	{
 		FlansMod.log.info("Registering Renderers");
-		
-		RenderManager rm = Minecraft.getMinecraft().getRenderManager();
 		
 		RenderingRegistry.registerEntityRenderingHandler(EntityBullet.class, new RenderBullet.Factory());
 		RenderingRegistry.registerEntityRenderingHandler(EntityGrenade.class, new RenderGrenade.Factory());

--- a/src/main/java/com/flansmod/client/ClientRenderHooks.java
+++ b/src/main/java/com/flansmod/client/ClientRenderHooks.java
@@ -155,7 +155,7 @@ public class ClientRenderHooks
 			if(customRenderers[typeType.ordinal()] != null && type.GetModel() != null)
 			{
 				// Cancel the hand render event so that we can do our own.
-				event.setCanceled(true);
+				//event.setCanceled(true);
 				
 				float partialTicks = event.getPartialTicks();
 				EntityRenderer renderer = mc.entityRenderer;

--- a/src/main/java/com/flansmod/client/ClientRenderHooks.java
+++ b/src/main/java/com/flansmod/client/ClientRenderHooks.java
@@ -161,8 +161,8 @@ public class ClientRenderHooks
 				EntityRenderer renderer = mc.entityRenderer;
 				float farPlaneDistance = mc.gameSettings.renderDistanceChunks * 16F;
 				ItemRenderer itemRenderer = mc.getItemRenderer();
-				
-				GlStateManager.clear(256);
+				//Unknown function. But definitely messes up the render pipeline, causing other mods and shaders to break
+				//GlStateManager.clear(256);
 				GlStateManager.matrixMode(5889);
 				GlStateManager.loadIdentity();
 				
@@ -817,12 +817,12 @@ public class ClientRenderHooks
 				&& (teamInfo.numTeams > 0 || !teamInfo.sortedByTeam)
 				&& PacketTeamInfo.getPlayerScoreData(FlansModClient.minecraft.player.getName()) != null)
 		{
-			GL11.glEnable(3042 /* GL_BLEND */);
-			GL11.glDisable(2929 /* GL_DEPTH_TEST */);
+			GlStateManager.enableBlend();
+			GL11.glDisable(GL11.GL_DEPTH_TEST);
 			GL11.glDepthMask(false);
 			GL11.glBlendFunc(770, 771);
-			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-			GL11.glDisable(3008 /* GL_ALPHA_TEST */);
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+			GL11.glDisable(GL11.GL_ALPHA_TEST);
 			
 			mc.renderEngine.bindTexture(GuiTeamScores.texture);
 			
@@ -847,7 +847,7 @@ public class ClientRenderHooks
 				
 				// Draw team 1 colour bit
 				int colour = teamInfo.teamData[0].team.teamColour;
-				GL11.glColor4f(((colour >> 16) & 0xff) / 256F, ((colour >> 8) & 0xff) / 256F, (colour & 0xff) / 256F,
+				GlStateManager.color(((colour >> 16) & 0xff) / 256F, ((colour >> 8) & 0xff) / 256F, (colour & 0xff) / 256F,
 						1.0F);
 				worldrenderer.startDrawingQuads();
 				worldrenderer.addVertexWithUV(i / 2d - 43, 27, -90D, 0D / 256D, 125D / 256D);
@@ -857,7 +857,7 @@ public class ClientRenderHooks
 				worldrenderer.draw();
 				// Draw team 2 colour bit
 				colour = teamInfo.teamData[1].team.teamColour;
-				GL11.glColor4f(((colour >> 16) & 0xff) / 256F, ((colour >> 8) & 0xff) / 256F, (colour & 0xff) / 256F,
+				GlStateManager.color(((colour >> 16) & 0xff) / 256F, ((colour >> 8) & 0xff) / 256F, (colour & 0xff) / 256F,
 						1.0F);
 				worldrenderer.startDrawingQuads();
 				worldrenderer.addVertexWithUV(i / 2d + 19, 27, -90D, 62D / 256D, 125D / 256D);
@@ -867,9 +867,9 @@ public class ClientRenderHooks
 				worldrenderer.draw();
 				
 				GL11.glDepthMask(true);
-				GL11.glEnable(2929 /* GL_DEPTH_TEST */);
-				GL11.glEnable(3008 /* GL_ALPHA_TEST */);
-				GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+				GL11.glEnable(GL11.GL_DEPTH_TEST);
+				GL11.glEnable(GL11.GL_ALPHA_TEST);
+				GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 				
 				// Draw the team scores
 				if(teamInfo.teamData[0] != null && teamInfo.teamData[1] != null)
@@ -903,9 +903,9 @@ public class ClientRenderHooks
 			
 			
 			GL11.glDepthMask(true);
-			GL11.glEnable(2929 /* GL_DEPTH_TEST */);
-			GL11.glEnable(3008 /* GL_ALPHA_TEST */);
-			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GL11.glEnable(GL11.GL_ALPHA_TEST);
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			String playerUsername = FlansModClient.minecraft.player.getName();
 			
 			PlayerScoreData data = PacketTeamInfo.getPlayerScoreData(playerUsername);
@@ -929,7 +929,7 @@ public class ClientRenderHooks
 		
 		// Draw icons indicated weapons used
 		RenderHelper.enableGUIStandardItemLighting();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 		
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);

--- a/src/main/java/com/flansmod/client/ClientRenderHooks.java
+++ b/src/main/java/com/flansmod/client/ClientRenderHooks.java
@@ -155,7 +155,7 @@ public class ClientRenderHooks
 			if(customRenderers[typeType.ordinal()] != null && type.GetModel() != null)
 			{
 				// Cancel the hand render event so that we can do our own.
-				//event.setCanceled(true);
+				event.setCanceled(true);
 				
 				float partialTicks = event.getPartialTicks();
 				EntityRenderer renderer = mc.entityRenderer;

--- a/src/main/java/com/flansmod/client/debug/RenderDebugAABB.java
+++ b/src/main/java/com/flansmod/client/debug/RenderDebugAABB.java
@@ -1,7 +1,6 @@
 package com.flansmod.client.debug;
 
-import org.lwjgl.opengl.GL11;
-
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -23,22 +22,19 @@ public class RenderDebugAABB extends Render<EntityDebugAABB>
 		if(!FlansMod.DEBUG)
 			return;
 		EntityDebugAABB ent = entity;
+		GlStateManager.disableTexture2D();
+		GlStateManager.enableBlend();
+		GlStateManager.color(ent.red, ent.green, ent.blue, 0.2F);
+		GlStateManager.pushMatrix();
 		
-		GL11.glDisable(GL11.GL_TEXTURE_2D);
-		//GL11.glDisable(GL11.GL_DEPTH_TEST);
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glColor4f(ent.red, ent.green, ent.blue, 0.2F);
-		GL11.glPushMatrix();
-		
-		GL11.glTranslatef((float)d0, (float)d1, (float)d2);
-		GL11.glRotatef(-ent.rotationYaw, 0F, 1F, 0F);
-		GL11.glRotatef(ent.rotationPitch, 1F, 0F, 0F);
-		GL11.glRotatef(ent.rotationRoll, 0F, 0F, 1F);
+		GlStateManager.translate((float)d0, (float)d1, (float)d2);
+		GlStateManager.rotate(-ent.rotationYaw, 0F, 1F, 0F);
+		GlStateManager.rotate(ent.rotationPitch, 1F, 0F, 0F);
+		GlStateManager.rotate(ent.rotationRoll, 0F, 0F, 1F);
 		renderOffsetAABB(new AxisAlignedBB(ent.offset.x, ent.offset.y, ent.offset.z, ent.offset.x + ent.vector.x, ent.offset.y + ent.vector.y, ent.offset.z + ent.vector.z), 0, 0, 0);
-		GL11.glPopMatrix();
-		GL11.glDisable(GL11.GL_BLEND);
-		GL11.glEnable(GL11.GL_TEXTURE_2D);
-		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		GlStateManager.popMatrix();
+		GlStateManager.disableBlend();
+		GlStateManager.enableTexture2D();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/debug/RenderDebugDot.java
+++ b/src/main/java/com/flansmod/client/debug/RenderDebugDot.java
@@ -2,6 +2,7 @@ package com.flansmod.client.debug;
 
 import org.lwjgl.opengl.GL11;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -23,17 +24,17 @@ public class RenderDebugDot extends Render<EntityDebugDot>
 		if(!FlansMod.DEBUG)
 			return;
 		
-		GL11.glDisable(GL11.GL_TEXTURE_2D);
+		GlStateManager.disableTexture2D();
 		GL11.glDisable(GL11.GL_DEPTH_TEST);
-		GL11.glColor3f(entity.getColorRed(), entity.getColorGreen(), entity.getColorBlue());
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d0, (float)d1, (float)d2);
+		GlStateManager.color(entity.getColorRed(), entity.getColorGreen(), entity.getColorBlue());
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d0, (float)d1, (float)d2);
 		GL11.glPointSize(10F);
-		GL11.glBegin(GL11.GL_POINTS);
-		GL11.glVertex3f(0F, 0F, 0F);
-		GL11.glEnd();
-		GL11.glPopMatrix();
-		GL11.glEnable(GL11.GL_TEXTURE_2D);
+		GlStateManager.glBegin(GL11.GL_POINTS);
+		GlStateManager.glVertex3f(0F, 0F, 0F);
+		GlStateManager.glEnd();
+		GlStateManager.popMatrix();
+		GlStateManager.enableTexture2D();
 		GL11.glEnable(GL11.GL_DEPTH_TEST);
 	}
 	

--- a/src/main/java/com/flansmod/client/debug/RenderDebugVector.java
+++ b/src/main/java/com/flansmod/client/debug/RenderDebugVector.java
@@ -2,6 +2,7 @@ package com.flansmod.client.debug;
 
 import org.lwjgl.opengl.GL11;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -23,18 +24,18 @@ public class RenderDebugVector extends Render<EntityDebugVector>
 		if(!FlansMod.DEBUG)
 			return;
 		
-		GL11.glDisable(GL11.GL_TEXTURE_2D);
+		GlStateManager.disableTexture2D();
 		GL11.glDisable(GL11.GL_DEPTH_TEST);
-		GL11.glColor3f(entity.getColorRed(), entity.getColorGreen(), entity.getColorBlue());
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d0, (float)d1, (float)d2);
-		GL11.glLineWidth(5F);
-		GL11.glBegin(GL11.GL_LINE_STRIP);
-		GL11.glVertex3f(0F, 0F, 0F);
-		GL11.glVertex3f(entity.getPointingX(), entity.getPointingY(), entity.getPointingZ());
-		GL11.glEnd();
-		GL11.glPopMatrix();
-		GL11.glEnable(GL11.GL_TEXTURE_2D);
+		GlStateManager.color(entity.getColorRed(), entity.getColorGreen(), entity.getColorBlue());
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d0, (float)d1, (float)d2);
+		GlStateManager.glLineWidth(5F);
+		GlStateManager.glBegin(GL11.GL_LINE_STRIP);
+		GlStateManager.glVertex3f(0F, 0F, 0F);
+		GlStateManager.glVertex3f(entity.getPointingX(), entity.getPointingY(), entity.getPointingZ());
+		GlStateManager.glEnd();
+		GlStateManager.popMatrix();
+		GlStateManager.enableTexture2D();
 		GL11.glEnable(GL11.GL_DEPTH_TEST);
 	}
 	

--- a/src/main/java/com/flansmod/client/gui/GuiArmourBox.java
+++ b/src/main/java/com/flansmod/client/gui/GuiArmourBox.java
@@ -9,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.RenderItem;
@@ -56,9 +57,9 @@ public class GuiArmourBox extends GuiScreen
 		int l = scaledresolution.getScaledHeight();
 		FontRenderer fontrenderer = mc.fontRenderer;
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		mc.renderEngine.bindTexture(texture);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		int m = guiOriginX = k / 2 - 88;
 		int n = guiOriginY = l / 2 - 91;
 		drawTexturedModalRect(m, n, 0, 0, 176, 182);
@@ -77,7 +78,7 @@ public class GuiArmourBox extends GuiScreen
 			drawTexturedModalRect(m + 89, n + 87, 186, 0, 10, 10);
 
 		RenderHelper.enableGUIStandardItemLighting();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
 
@@ -110,7 +111,7 @@ public class GuiArmourBox extends GuiScreen
 		ArmourBoxEntry page = type.pages.get(q);
 		if(page != null)
 		{
-			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			//fontRenderer.drawString(type.guns[q].name, m + 9, n + 22, 0xffffffff);
 			
 			//Iterate over x

--- a/src/main/java/com/flansmod/client/gui/GuiDriveableCrafting.java
+++ b/src/main/java/com/flansmod/client/gui/GuiDriveableCrafting.java
@@ -114,10 +114,10 @@ public class GuiDriveableCrafting extends GuiScreen
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		//Bind the background texture
 		mc.renderEngine.bindTexture(texture);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		guiOriginX = w / 2 - 88;
 		guiOriginY = h / 2 - 99;
 		//Draw the background
@@ -168,10 +168,10 @@ public class GuiDriveableCrafting extends GuiScreen
 		if(selectedType != null)
 		{
 			//Render rotating driveable model
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
 			GL11.glEnable(GL11.GL_ALPHA_TEST);
-			GL11.glTranslatef(w / 2 - 46, h / 2 - 10, 100);
+			GlStateManager.translate(w / 2 - 46, h / 2 - 10, 100);
 			
 			//Do lights
 			GlStateManager.disableLighting();
@@ -183,16 +183,16 @@ public class GuiDriveableCrafting extends GuiScreen
 			GlStateManager.enableRescaleNormal();
 			
 			if(selectedType instanceof MechaType)
-				GL11.glTranslatef(0, 15, 0);
-			GL11.glScalef(-50F * selectedType.modelScale / selectedType.cameraDistance, 50F * selectedType.modelScale / selectedType.cameraDistance, 50F * selectedType.modelScale / selectedType.cameraDistance);
-			GL11.glRotatef(180F, 0F, 0F, 1F);
-			GL11.glRotatef(30F, 1F, 0F, 0F);
-			GL11.glRotatef(spinner / 5F, 0F, 1F, 0F);
+				GlStateManager.translate(0, 15, 0);
+			GlStateManager.scale(-50F * selectedType.modelScale / selectedType.cameraDistance, 50F * selectedType.modelScale / selectedType.cameraDistance, 50F * selectedType.modelScale / selectedType.cameraDistance);
+			GlStateManager.rotate(180F, 0F, 0F, 1F);
+			GlStateManager.rotate(30F, 1F, 0F, 0F);
+			GlStateManager.rotate(spinner / 5F, 0F, 1F, 0F);
 			mc.renderEngine.bindTexture(FlansModResourceHandler.getTexture(selectedType));
 			selectedType.model.render(selectedType);
 			GL11.glDisable(GL11.GL_DEPTH_TEST);
 			GL11.glDisable(GL11.GL_ALPHA_TEST);
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			recipeName = selectedType.name;
 			if(recipeName.length() > 16)

--- a/src/main/java/com/flansmod/client/gui/GuiDriveableFuel.java
+++ b/src/main/java/com/flansmod/client/gui/GuiDriveableFuel.java
@@ -2,9 +2,8 @@ package com.flansmod.client.gui;
 
 import java.io.IOException;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -49,7 +48,7 @@ public class GuiDriveableFuel extends GuiContainer
 			if(newTime % 5 == 0)
 				anim++;
 		}
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 
 		mc.renderEngine.bindTexture(texture);
 

--- a/src/main/java/com/flansmod/client/gui/GuiDriveableInventory.java
+++ b/src/main/java/com/flansmod/client/gui/GuiDriveableInventory.java
@@ -56,7 +56,7 @@ public class GuiDriveableInventory extends GuiContainer
 		fontRenderer.drawString("Inventory", 8, (ySize - 96) + 2, 0x404040);
 
 		RenderHelper.enableGUIStandardItemLighting();
-		GL11.glColor3f(1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F);
 		if(screen == 0)
 		{
 			int slotsDone = 0;
@@ -89,7 +89,7 @@ public class GuiDriveableInventory extends GuiContainer
 				}
 			}
 		}
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 		RenderHelper.disableStandardItemLighting();
 		GL11.glDisable(GL11.GL_LIGHTING);
@@ -129,7 +129,7 @@ public class GuiDriveableInventory extends GuiContainer
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float f, int i1, int j1)
 	{
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 
 		mc.renderEngine.bindTexture(texture);
 

--- a/src/main/java/com/flansmod/client/gui/GuiDriveableMenu.java
+++ b/src/main/java/com/flansmod/client/gui/GuiDriveableMenu.java
@@ -1,9 +1,8 @@
 package com.flansmod.client.gui;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -112,7 +111,7 @@ public class GuiDriveableMenu extends GuiContainer
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float f, int i1, int j1)
 	{
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		mc.renderEngine.bindTexture(texture);
 		int j = (width - xSize) / 2;
 		int k = (height - ySize) / 2;

--- a/src/main/java/com/flansmod/client/gui/GuiDriveableRepair.java
+++ b/src/main/java/com/flansmod/client/gui/GuiDriveableRepair.java
@@ -3,11 +3,10 @@ package com.flansmod.client.gui;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -113,11 +112,11 @@ public class GuiDriveableRepair extends GuiScreen
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
 		//Bind the background texture
 		mc.renderEngine.bindTexture(texture);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		//Calculate the gui origin
 		guiOriginX = w / 2 - guiWidth / 2;
 		guiOriginY = h / 2 - guiHeight / 2;
@@ -141,7 +140,7 @@ public class GuiDriveableRepair extends GuiScreen
 			
 			//Render the damage bar
 			float percentHealth = (float)part.health / (float)part.maxHealth;
-			GL11.glColor3f(1 - percentHealth, percentHealth, 0F);
+			GlStateManager.color(1 - percentHealth, percentHealth, 0F);
 			drawTexturedModalRect(guiOriginX + 121, guiOriginY + y + 2, 0, 73, (int)(70 * percentHealth), 16);
 			
 			//Write the part name and percent health

--- a/src/main/java/com/flansmod/client/gui/GuiGunModTable.java
+++ b/src/main/java/com/flansmod/client/gui/GuiGunModTable.java
@@ -55,8 +55,8 @@ public class GuiGunModTable extends GuiContainer
 			GunType gunType = ((ItemGun)gunStack.getItem()).GetType();
 			if(gunType.model != null)
 			{
-				GL11.glPushMatrix();
-				GL11.glColor4f(1F, 1F, 1F, 1F);
+				GlStateManager.pushMatrix();
+				GlStateManager.color(1F, 1F, 1F, 1F);
 				
 				GlStateManager.disableLighting();
 				GlStateManager.pushMatrix();
@@ -66,14 +66,14 @@ public class GuiGunModTable extends GuiContainer
 				GlStateManager.popMatrix();
 				GlStateManager.enableRescaleNormal();
 				
-				GL11.glTranslatef(80, 48, 100);
+				GlStateManager.translate(80, 48, 100);
 				
-				GL11.glRotatef(160, 1F, 0F, 0F);
-				GL11.glRotatef(20, 0F, 1F, 0F);
-				GL11.glScalef(-50F, 50F, 50F);
+				GlStateManager.rotate(160, 1F, 0F, 0F);
+				GlStateManager.rotate(20, 0F, 1F, 0F);
+				GlStateManager.scale(-50F, 50F, 50F);
 				//ClientProxy.gunRenderer.renderGun(gunStack, gunType, 1F / 16F, gunType.model, GunAnimations.defaults, 0F);
 				ClientProxy.gunRenderer.renderItem(CustomItemRenderType.ENTITY, EnumHand.MAIN_HAND, tempStack);
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 			}
 		}
 	}
@@ -81,7 +81,7 @@ public class GuiGunModTable extends GuiContainer
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float f, int i, int j)
 	{
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		
 		mc.renderEngine.bindTexture(texture);
 		
@@ -192,7 +192,7 @@ public class GuiGunModTable extends GuiContainer
 						haveDyes[n] = true;
 				}
 				
-				GL11.glColor4f(1F, 1F, 1F, 1F);
+				GlStateManager.color(1F, 1F, 1F, 1F);
 				GL11.glDisable(GL11.GL_LIGHTING);
 				mc.renderEngine.bindTexture(texture);
 				

--- a/src/main/java/com/flansmod/client/gui/GuiMechaInventory.java
+++ b/src/main/java/com/flansmod/client/gui/GuiMechaInventory.java
@@ -7,6 +7,7 @@ import org.lwjgl.opengl.GL11;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -70,7 +71,7 @@ public class GuiMechaInventory extends GuiContainer
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float f, int i1, int j1)
 	{
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		
 		mc.renderEngine.bindTexture(texture);
 		
@@ -103,21 +104,21 @@ public class GuiMechaInventory extends GuiContainer
 		
 		MechaType type = mecha.getMechaType();
 		//Render rotating mecha model
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		GL11.glEnable(GL11.GL_DEPTH_TEST);
-		GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		GL11.glTranslatef(j + 92, k + 105, 100);
-		GL11.glScalef(-50F / type.cameraDistance, 50F / type.cameraDistance, 50F / type.cameraDistance);
-		GL11.glRotatef(180F, 0F, 0F, 1F);
-		GL11.glRotatef(30F, 1F, 0F, 0F);
-		GL11.glRotatef(FlansMod.ticker, 0F, 1F, 0F);
+		GlStateManager.enableLighting();
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.translate(j + 92, k + 105, 100);
+		GlStateManager.scale(-50F / type.cameraDistance, 50F / type.cameraDistance, 50F / type.cameraDistance);
+		GlStateManager.rotate(180F, 0F, 0F, 1F);
+		GlStateManager.rotate(30F, 1F, 0F, 0F);
+		GlStateManager.rotate(FlansMod.ticker, 0F, 1F, 0F);
 		mc.renderEngine.bindTexture(FlansModResourceHandler.getTexture(type));
 		mechaRenderer.doRender(mecha, 0, 0, 0, 0F, 0F);
 		//type.model.render(type);
-		GL11.glDisable(GL11.GL_LIGHTING);
+		GlStateManager.disableLighting();
 		GL11.glDisable(GL11.GL_DEPTH_TEST);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/gui/GuiPaintjobTable.java
+++ b/src/main/java/com/flansmod/client/gui/GuiPaintjobTable.java
@@ -240,8 +240,8 @@ public class GuiPaintjobTable extends GuiContainer
 			EnumType eType = EnumType.getFromObject(paintableType);
 			if(paintableType.GetModel() != null)
 			{
-				GL11.glPushMatrix();
-				GL11.glColor4f(1F, 1F, 1F, 1F);
+				GlStateManager.pushMatrix();
+				GlStateManager.color(1F, 1F, 1F, 1F);
 				
 				//GlStateManager.loadIdentity();
 
@@ -253,14 +253,14 @@ public class GuiPaintjobTable extends GuiContainer
 				GlStateManager.popMatrix();
 				GlStateManager.enableRescaleNormal();
 
-				//GL11.glTranslatef(10f, 10f, -10f);
-				//GL11.glScalef(100f, 100f, 100f);
-				GL11.glTranslatef(renderOrigin.x, renderOrigin.y, renderOrigin.z);
+				//GlStateManager.translate(10f, 10f, -10f);
+				//GlStateManager.scale(100f, 100f, 100f);
+				GlStateManager.translate(renderOrigin.x, renderOrigin.y, renderOrigin.z);
 
-				GL11.glRotatef(180, 1F, 0F, 0F);
-				//GL11.glRotatef(20, 0F, 1F, 0F);
+				GlStateManager.rotate(180, 1F, 0F, 0F);
+				//GlStateManager.rotate(20, 0F, 1F, 0F);
 				float scale = paintableType.GetRecommendedScale();
-				GL11.glScalef(-scale, scale, scale);
+				GlStateManager.scale(-scale, scale, scale);
 				
 				float dYaw = (modelAxes.getYaw() - prevModelAxes.getYaw());
 				while(dYaw > 180.0f) dYaw -= 360.0f;
@@ -305,7 +305,7 @@ public class GuiPaintjobTable extends GuiContainer
 					default: break;
 				}
 				
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 			}
 		}
 	}
@@ -313,7 +313,7 @@ public class GuiPaintjobTable extends GuiContainer
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float f, int i, int j)
 	{
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GlStateManager.disableDepth();
 		
 		mc.renderEngine.bindTexture(texture);
@@ -380,7 +380,7 @@ public class GuiPaintjobTable extends GuiContainer
 							haveDyes[n] = true;
 					}
 
-					GL11.glColor4f(1F, 1F, 1F, 1F);
+					GlStateManager.color(1F, 1F, 1F, 1F);
 					GL11.glDisable(GL11.GL_LIGHTING);
 					mc.renderEngine.bindTexture(texture);
 

--- a/src/main/java/com/flansmod/client/gui/teams/GuiBaseEditor.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiBaseEditor.java
@@ -4,13 +4,12 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.lwjgl.input.Keyboard;
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 
 import com.flansmod.common.FlansMod;
@@ -82,9 +81,9 @@ public class GuiBaseEditor extends GuiScreen
 		int l = scaledresolution.getScaledHeight();
 		FontRenderer fontrenderer = mc.fontRenderer;
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		mc.renderEngine.bindTexture(texture);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		int m = guiOriginX = k / 2 - 128;
 		int n = guiOriginY = l / 2 - 94;
 		drawTexturedModalRect(m, n, 0, 0, 256, 189);

--- a/src/main/java/com/flansmod/client/gui/teams/GuiChooseLoadout.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiChooseLoadout.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.client.FMLClientHandler;
 
@@ -80,9 +81,9 @@ public class GuiChooseLoadout extends GuiTeamsBase
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		guiOriginX = w / 2 - 128;
 		guiOriginY = h / 2 - 99;
 		

--- a/src/main/java/com/flansmod/client/gui/teams/GuiEditLoadout.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiEditLoadout.java
@@ -104,9 +104,9 @@ public class GuiEditLoadout extends GuiTeamsBase
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		guiOriginX = w / 2 - WIDTH / 2;
 		guiOriginY = h / 2 - HEIGHT / 2;
 		

--- a/src/main/java/com/flansmod/client/gui/teams/GuiLandingPage.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiLandingPage.java
@@ -1,9 +1,8 @@
 package com.flansmod.client.gui.teams;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -96,9 +95,9 @@ public class GuiLandingPage extends GuiTeamsBase
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		guiOriginX = w / 2 - WIDTH / 2;
 		guiOriginY = h / 2 - HEIGHT / 2;
 		

--- a/src/main/java/com/flansmod/client/gui/teams/GuiMissionResults.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiMissionResults.java
@@ -6,6 +6,7 @@ import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -327,9 +328,9 @@ public class GuiMissionResults extends GuiTeamsBase
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		guiOriginX = w / 2 - WIDTH / 2;
 		guiOriginY = h / 2 - HEIGHT / 2;
 		

--- a/src/main/java/com/flansmod/client/gui/teams/GuiOpenRewardBox.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiOpenRewardBox.java
@@ -222,9 +222,9 @@ public class GuiOpenRewardBox extends GuiTeamsBase
 		int w = scaledresolution.getScaledWidth();
 		int h = scaledresolution.getScaledHeight();
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		guiOriginX = w / 2 - WIDTH / 2;
 		guiOriginY = h / 2 - HEIGHT / 2;
 		

--- a/src/main/java/com/flansmod/client/gui/teams/GuiTeamScores.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiTeamScores.java
@@ -43,13 +43,13 @@ public class GuiTeamScores extends GuiTeamsBase
 		int l = scaledresolution.getScaledHeight();
 		FontRenderer fontrenderer = mc.fontRenderer;
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
 		mc.renderEngine.bindTexture(texture2);
 		
 		int guiHeight = 68 + 9 * teamInfo.numLines;
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		int m = k / 2 - 156;
 		int n = l / 2 - guiHeight / 2;
 		//Like draw texturedModalRect, but with custom image size
@@ -163,11 +163,11 @@ public class GuiTeamScores extends GuiTeamsBase
 		int l = scaledresolution.getScaledHeight();
 		FontRenderer fontrenderer = mc.fontRenderer;
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
 		mc.renderEngine.bindTexture(texture);
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		int guiHeight = 34 + 9 * teamInfo.numLines;
 		int m = k / 2 - 128;
 		int n = l / 2 - guiHeight / 2;

--- a/src/main/java/com/flansmod/client/gui/teams/GuiTeamSelect.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiTeamSelect.java
@@ -1,10 +1,9 @@
 package com.flansmod.client.gui.teams;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -90,7 +89,7 @@ public class GuiTeamSelect extends GuiScreen
 	public void drawScreen(int i, int j, float f)
 	{
 		//TODO : Draw the inventory BG and slots for the class menu
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		drawDefaultBackground();
 		mc.renderEngine.bindTexture(texture);
 		drawTexturedModalRect(width / 2 - 128, height / 2 - guiHeight / 2, 0, 0, 256, 22);

--- a/src/main/java/com/flansmod/client/gui/teams/GuiTeamsBase.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiTeamsBase.java
@@ -133,10 +133,10 @@ public class GuiTeamsBase extends GuiScreen
 			GunType gunType = ((ItemGun)stack.getItem()).GetType();
 			if(gunType.model != null)
 			{
-				GL11.glPushMatrix();
-				GL11.glColor4f(1F, 1F, 1F, 1F);
+				GlStateManager.pushMatrix();
+				GlStateManager.color(1F, 1F, 1F, 1F);
 				
-				GL11.glTranslatef(x, y, 100);
+				GlStateManager.translate(x, y, 100);
 				
 				GlStateManager.disableLighting();
 				GlStateManager.pushMatrix();
@@ -147,14 +147,14 @@ public class GuiTeamsBase extends GuiScreen
 				GlStateManager.popMatrix();
 				GlStateManager.enableRescaleNormal();
 				
-				GL11.glRotatef(160, 1F, 0F, 0F);
-				GL11.glRotatef(10, 0F, 1F, 0F);
-				GL11.glScalef(-scale, scale, scale);
+				GlStateManager.rotate(160, 1F, 0F, 0F);
+				GlStateManager.rotate(10, 0F, 1F, 0F);
+				GlStateManager.scale(-scale, scale, scale);
 				ClientProxy.gunRenderer.renderItem(CustomItemRenderType.ENTITY, EnumHand.MAIN_HAND, stack);
 				
 				RenderHelper.disableStandardItemLighting();
 				
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 			}
 		}
 	}

--- a/src/main/java/com/flansmod/client/gui/teams/GuiVoting.java
+++ b/src/main/java/com/flansmod/client/gui/teams/GuiVoting.java
@@ -1,11 +1,10 @@
 package com.flansmod.client.gui.teams;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 
 import com.flansmod.client.teams.ClientTeamsData;
@@ -54,12 +53,12 @@ public class GuiVoting extends GuiScreen
 		int l = scaledresolution.getScaledHeight();
 		FontRenderer fontrenderer = mc.fontRenderer;
 		drawDefaultBackground();
-		GL11.glEnable(3042 /*GL_BLEND*/);
+		GlStateManager.enableBlend();
 		
 		mc.renderEngine.bindTexture(texture);
 		
 		
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		int m = k / 2 - 128;
 		int n = l / 2 - guiHeight / 2;
 		

--- a/src/main/java/com/flansmod/client/handlers/ClientEventHandler.java
+++ b/src/main/java/com/flansmod/client/handlers/ClientEventHandler.java
@@ -13,6 +13,7 @@ import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.client.event.RenderSpecificHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -130,7 +131,7 @@ public class ClientEventHandler
 		renderHooks.renderItemFrame(event);
 	}
 	
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.LOW)
 	public void renderHeldItem(RenderSpecificHandEvent event)
 	{
 		renderHooks.renderHeldItem(event);

--- a/src/main/java/com/flansmod/client/handlers/ClientEventHandler.java
+++ b/src/main/java/com/flansmod/client/handlers/ClientEventHandler.java
@@ -131,7 +131,7 @@ public class ClientEventHandler
 		renderHooks.renderItemFrame(event);
 	}
 	
-	@SubscribeEvent(priority = EventPriority.LOW)
+	@SubscribeEvent
 	public void renderHeldItem(RenderSpecificHandEvent event)
 	{
 		renderHooks.renderHeldItem(event);

--- a/src/main/java/com/flansmod/client/handlers/ClientEventHandler.java
+++ b/src/main/java/com/flansmod/client/handlers/ClientEventHandler.java
@@ -13,7 +13,6 @@ import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.client.event.RenderSpecificHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;

--- a/src/main/java/com/flansmod/client/model/InstantBulletRenderer.java
+++ b/src/main/java/com/flansmod/client/model/InstantBulletRenderer.java
@@ -102,7 +102,7 @@ public class InstantBulletRenderer
 			double y = camera.lastTickPosY + (camera.posY - camera.lastTickPosY) * partialTicks;
 			double z = camera.lastTickPosZ + (camera.posZ - camera.lastTickPosZ) * partialTicks;
 			
-			GL11.glTranslatef(-(float)x, -(float)y, -(float)z);
+			GlStateManager.translate(-(float)x, -(float)y, -(float)z);
 			
 			float parametric = ((float)(ticksExisted) + partialTicks) * bulletSpeed;
 			
@@ -138,6 +138,9 @@ public class InstantBulletRenderer
 			worldrenderer.addVertexWithUV(startPos.x - trailTangent.x, startPos.y - trailTangent.y, startPos.z - trailTangent.z, 0.0f, 1.0f);
 			worldrenderer.addVertexWithUV(endPos.x - trailTangent.x, endPos.y - trailTangent.y, endPos.z - trailTangent.z, 1.0f, 1.0f);
 			worldrenderer.addVertexWithUV(endPos.x + trailTangent.x, endPos.y + trailTangent.y, endPos.z + trailTangent.z, 1.0f, 0.0f);
+			
+//			worldrenderer.addVertexWithUV(endPos.x + trailTangent.x*10, endPos.y + trailTangent.y*10, endPos.z + trailTangent.z*10, 1.0f, 0.0f);
+			
 			worldrenderer.draw();
 			
 			GlStateManager.disableRescaleNormal();

--- a/src/main/java/com/flansmod/client/model/ModelBullet.java
+++ b/src/main/java/com/flansmod/client/model/ModelBullet.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 public class ModelBullet extends ModelBase
@@ -19,7 +20,7 @@ public class ModelBullet extends ModelBase
 	@Override
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
-		GL11.glScalef(0.5F, 0.5F, 0.5F);
+		GlStateManager.scale(0.5F, 0.5F, 0.5F);
 		bulletModel.render(f5);
 	}
 }

--- a/src/main/java/com/flansmod/client/model/ModelCustomArmour.java
+++ b/src/main/java/com/flansmod/client/model/ModelCustomArmour.java
@@ -29,8 +29,8 @@ public class ModelCustomArmour extends ModelBiped
 	
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
-		GL11.glPushMatrix();
-		GL11.glScalef(type.modelScale, type.modelScale, type.modelScale);
+		GlStateManager.pushMatrix();
+		GlStateManager.scale(type.modelScale, type.modelScale, type.modelScale);
 		isSneak = entity.isSneaking();
 		ItemStack itemstack = ((EntityLivingBase)entity).getItemStackFromSlot(EntityEquipmentSlot.MAINHAND);
 		rightArmPose = itemstack.isEmpty() ? ArmPose.EMPTY : ArmPose.ITEM;
@@ -84,7 +84,7 @@ public class ModelCustomArmour extends ModelBiped
 				mod.render(f5);
 			}
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	public void render(ModelRendererTurbo[] models, ModelRenderer bodyPart, float f5, float scale)

--- a/src/main/java/com/flansmod/client/model/ModelMecha.java
+++ b/src/main/java/com/flansmod/client/model/ModelMecha.java
@@ -1,7 +1,5 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import com.flansmod.client.tmt.ModelRendererTurbo;
 import com.flansmod.common.driveables.DriveableType;
 import com.flansmod.common.driveables.EntityDriveable;
@@ -9,6 +7,8 @@ import com.flansmod.common.driveables.EnumDriveablePart;
 import com.flansmod.common.driveables.mechas.EntityMecha;
 import com.flansmod.common.driveables.mechas.MechaType;
 import com.flansmod.common.vector.Vector3f;
+
+import net.minecraft.client.renderer.GlStateManager;
 
 public class ModelMecha extends ModelDriveable
 {
@@ -64,16 +64,16 @@ public class ModelMecha extends ModelDriveable
 		renderPart(rightFrontFootModel);
 		renderPart(barrelModel);
 		renderPart(headModel);
-		GL11.glPushMatrix();
-		GL11.glTranslatef(mechaType.leftArmOrigin.x / mechaType.modelScale, mechaType.leftArmOrigin.y / mechaType.modelScale, mechaType.leftArmOrigin.z / mechaType.modelScale);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(mechaType.leftArmOrigin.x / mechaType.modelScale, mechaType.leftArmOrigin.y / mechaType.modelScale, mechaType.leftArmOrigin.z / mechaType.modelScale);
 		renderPart(leftArmModel);
 		renderPart(leftHandModel);
-		GL11.glPopMatrix();
-		GL11.glPushMatrix();
-		GL11.glTranslatef(mechaType.rightArmOrigin.x / mechaType.modelScale, mechaType.rightArmOrigin.y / mechaType.modelScale, mechaType.rightArmOrigin.z / mechaType.modelScale);
+		GlStateManager.popMatrix();
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(mechaType.rightArmOrigin.x / mechaType.modelScale, mechaType.rightArmOrigin.y / mechaType.modelScale, mechaType.rightArmOrigin.z / mechaType.modelScale);
 		renderPart(rightArmModel);
 		renderPart(rightHandModel);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	public void render(float f5, EntityMecha mecha, float f)

--- a/src/main/java/com/flansmod/client/model/ModelMechaTool.java
+++ b/src/main/java/com/flansmod/client/model/ModelMechaTool.java
@@ -1,8 +1,7 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 
 import com.flansmod.client.tmt.ModelRendererTurbo;
 import com.flansmod.common.driveables.mechas.EntityMecha;
@@ -44,15 +43,15 @@ public class ModelMechaTool extends ModelBase
 		
 		for(ModelRendererTurbo model : sawModel)
 		{
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			if(spin)
 			{
-				GL11.glTranslatef(model.rotationPointX / 16F, model.rotationPointY / 16F, model.rotationPointZ / 16F);
-				GL11.glRotatef(25F * (float)mecha.ticksExisted, 0F, 1F, 0F);
-				GL11.glTranslatef(-model.rotationPointX / 16F, -model.rotationPointY / 16F, -model.rotationPointZ / 16F);
+				GlStateManager.translate(model.rotationPointX / 16F, model.rotationPointY / 16F, model.rotationPointZ / 16F);
+				GlStateManager.rotate(25F * (float)mecha.ticksExisted, 0F, 1F, 0F);
+				GlStateManager.translate(-model.rotationPointX / 16F, -model.rotationPointY / 16F, -model.rotationPointZ / 16F);
 			}
 			model.render(f5);
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 	}

--- a/src/main/java/com/flansmod/client/model/RenderAAGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderAAGun.java
@@ -1,7 +1,6 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -22,9 +21,9 @@ public class RenderAAGun extends Render<EntityAAGun>
 	public void render(EntityAAGun aa, double d, double d1, double d2, float f, float f1)
 	{
 		bindEntityTexture(aa);
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
-		GL11.glScalef(1F, 1F, 1.0F);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
+		GlStateManager.scale(1F, 1F, 1.0F);
 		
 		float dYaw = aa.gunYaw - aa.prevGunYaw;
 		for(; dYaw > 180F; dYaw -= 360F)
@@ -38,10 +37,10 @@ public class RenderAAGun extends Render<EntityAAGun>
 		if(modelAAGun != null)
 		{
 			modelAAGun.renderBase(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, aa);
-			GL11.glRotatef(180F - (aa.prevGunYaw + dYaw * f1), 0.0F, 1.0F, 0.0F);
+			GlStateManager.rotate(180F - (aa.prevGunYaw + dYaw * f1), 0.0F, 1.0F, 0.0F);
 			modelAAGun.renderGun(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, aa);
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/model/RenderBullet.java
+++ b/src/main/java/com/flansmod/client/model/RenderBullet.java
@@ -1,8 +1,7 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -25,14 +24,14 @@ public class RenderBullet extends Render<EntityBullet>
 		//if(bullet.owner == Minecraft.getMinecraft().player && bullet.ticksExisted < 1)
 		//	return;
 		bindEntityTexture(bullet);
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
-		GL11.glRotatef(f, 0.0F, 1.0F, 0.0F);
-		GL11.glRotatef(90F - bullet.prevRotationPitch - (bullet.rotationPitch - bullet.prevRotationPitch) * f1, 1.0F, 0.0F, 0.0F);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
+		GlStateManager.rotate(f, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(90F - bullet.prevRotationPitch - (bullet.rotationPitch - bullet.prevRotationPitch) * f1, 1.0F, 0.0F, 0.0F);
 		ModelBase model = bullet.getFiredShot().getBulletType().model;
 		if(model != null)
 			model.render(bullet, 0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/model/RenderFlag.java
+++ b/src/main/java/com/flansmod/client/model/RenderFlag.java
@@ -1,7 +1,6 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -36,40 +35,40 @@ public class RenderFlag extends Render<EntityFlag>
 			//Give each team a default colour
 			switch(teamID)
 			{
-				case 0: GL11.glColor3f(0x80 / 255F, 0x80 / 255F, 0x80 / 255F);
+				case 0: GlStateManager.color(0x80 / 255F, 0x80 / 255F, 0x80 / 255F);
 					break; //No team
-				case 1: GL11.glColor3f(0x40 / 255F, 0x40 / 255F, 0x40 / 255F);
+				case 1: GlStateManager.color(0x40 / 255F, 0x40 / 255F, 0x40 / 255F);
 					break; //Spectators
-				case 2: GL11.glColor3f(0xa1 / 255F, 0x7f / 255F, 0xff / 255F);
+				case 2: GlStateManager.color(0xa1 / 255F, 0x7f / 255F, 0xff / 255F);
 					break; //Team 1
-				case 3: GL11.glColor3f(0xff / 255F, 0x7f / 255F, 0xb6 / 255F);
+				case 3: GlStateManager.color(0xff / 255F, 0x7f / 255F, 0xb6 / 255F);
 					break; //Team 2
 			}
 		}
 		else
 		{
 			int colour = team.teamColour;
-			GL11.glColor3f(((colour >> 16) & 0xff) / 255F, ((colour >> 8) & 0xff) / 255F, (colour & 0xff) / 255F);
+			GlStateManager.color(((colour >> 16) & 0xff) / 255F, ((colour >> 8) & 0xff) / 255F, (colour & 0xff) / 255F);
 		}
 		
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
-		GL11.glRotatef(f, 0.0F, 1.0F, 0.0F);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
+		GlStateManager.rotate(f, 0.0F, 1.0F, 0.0F);
 		
 		if(!(flag.getRidingEntity() instanceof EntityFlagpole))
 		{
-			GL11.glRotatef(angle, 0.0F, 1.0F, 0.0F);
-			GL11.glTranslatef(0.5F, 0F, 0F);
+			GlStateManager.rotate(angle, 0.0F, 1.0F, 0.0F);
+			GlStateManager.translate(0.5F, 0F, 0F);
 		}
 		else
 		{
-			GL11.glTranslatef(0F, 0.5F, 0F);
+			GlStateManager.translate(0F, 0.5F, 0F);
 		}
 		
-		GL11.glScalef(-1F, -1F, 1F);
+		GlStateManager.scale(-1F, -1F, 1F);
 		modelFlagpole.renderFlag(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, flag);
-		GL11.glPopMatrix();
-		GL11.glColor3f(1F, 1F, 1F);
+		GlStateManager.popMatrix();
+		GlStateManager.color(1F, 1F, 1F);
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/model/RenderFlagpole.java
+++ b/src/main/java/com/flansmod/client/model/RenderFlagpole.java
@@ -1,7 +1,6 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -25,15 +24,15 @@ public class RenderFlagpole extends Render<EntityFlagpole>
 	public void doRender(EntityFlagpole flagpole, double d, double d1, double d2, float f, float f1)
 	{
 		bindEntityTexture(flagpole);
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
-		GL11.glRotatef(f, 0.0F, 1.0F, 0.0F);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
+		GlStateManager.rotate(f, 0.0F, 1.0F, 0.0F);
 		
-		GL11.glScalef(-1F, -1F, 1F);
-		GL11.glColor3f(1F, 1F, 1F);
+		GlStateManager.scale(-1F, -1F, 1F);
+		GlStateManager.color(1F, 1F, 1F);
 		
 		modelFlagpole.renderPole(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, flagpole);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/model/RenderGrenade.java
+++ b/src/main/java/com/flansmod/client/model/RenderGrenade.java
@@ -1,9 +1,8 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.item.ItemStack;
@@ -28,13 +27,13 @@ public class RenderGrenade extends Render<EntityGrenade> implements CustomItemRe
 	public void doRender(EntityGrenade grenade, double d, double d1, double d2, float f, float f1)
 	{
 		bindEntityTexture(grenade);
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
 		if(grenade.stuck)
 		{
-			GL11.glRotatef(180F - grenade.axes.getYaw(), 0.0F, 1.0F, 0.0F);
-			GL11.glRotatef(grenade.axes.getPitch(), 0.0F, 0.0F, 1.0F);
-			GL11.glRotatef(grenade.axes.getRoll(), 1.0F, 0.0F, 0.0F);
+			GlStateManager.rotate(180F - grenade.axes.getYaw(), 0.0F, 1.0F, 0.0F);
+			GlStateManager.rotate(grenade.axes.getPitch(), 0.0F, 0.0F, 1.0F);
+			GlStateManager.rotate(grenade.axes.getRoll(), 1.0F, 0.0F, 0.0F);
 		}
 		else
 		{
@@ -59,14 +58,14 @@ public class RenderGrenade extends Render<EntityGrenade> implements CustomItemRe
 			for(; dRoll <= -180F; dRoll += 360F)
 			{
 			}
-			GL11.glRotatef(180F - grenade.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
-			GL11.glRotatef(grenade.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
-			GL11.glRotatef(grenade.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
+			GlStateManager.rotate(180F - grenade.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
+			GlStateManager.rotate(grenade.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
+			GlStateManager.rotate(grenade.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
 		}
 		ModelBase model = grenade.type.model;
 		if(model != null)
 			model.render(grenade, 0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override
@@ -92,7 +91,7 @@ public class RenderGrenade extends Render<EntityGrenade> implements CustomItemRe
 	@Override
 	public void renderItem(CustomItemRenderType type, EnumHand hand, ItemStack item, Object... data)
 	{
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		if(item != null && item.getItem() instanceof ItemGrenade)
 		{
 			GrenadeType grenadeType = ((ItemGrenade)item.getItem()).type;
@@ -102,23 +101,23 @@ public class RenderGrenade extends Render<EntityGrenade> implements CustomItemRe
 				{
 					case EQUIPPED:
 					{
-						//GL11.glRotatef(35F, 0F, 0F, 1F);
-						//GL11.glRotatef(-5F, 0F, 1F, 0F);
-						//GL11.glTranslatef(0.75F, -0.22F, -0.08F);
-						//GL11.glTranslatef(0F, 0.25F, 0F);
+						//GlStateManager.rotate(35F, 0F, 0F, 1F);
+						//GlStateManager.rotate(-5F, 0F, 1F, 0F);
+						//GlStateManager.translate(0.75F, -0.22F, -0.08F);
+						//GlStateManager.translate(0F, 0.25F, 0F);
 						break;
 					}
 					case EQUIPPED_FIRST_PERSON:
 					{
 						if(hand == EnumHand.MAIN_HAND)
 						{
-							GL11.glTranslatef(-1.25F, 0.8F, 0.1F);
+							GlStateManager.translate(-1.25F, 0.8F, 0.1F);
 						}
 						else
 						{
-							GL11.glRotatef(45F, 0F, 1F, 0F);
-							GL11.glTranslatef(-1F, 0.8F, -2F);
-							GL11.glRotatef(-135F, 0F, 1F, 0F);
+							GlStateManager.rotate(45F, 0F, 1F, 0F);
+							GlStateManager.translate(-1F, 0.8F, -2F);
+							GlStateManager.rotate(-135F, 0F, 1F, 0F);
 						}
 						break;
 					}
@@ -130,7 +129,7 @@ public class RenderGrenade extends Render<EntityGrenade> implements CustomItemRe
 				model.render(null, 0F, 0F, 0F, 0F, 0F, 1F / 16F);
 			}
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	public static class Factory implements IRenderFactory<EntityGrenade>

--- a/src/main/java/com/flansmod/client/model/RenderGun.java
+++ b/src/main/java/com/flansmod/client/model/RenderGun.java
@@ -1,8 +1,7 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -73,7 +72,7 @@ public class RenderGun implements CustomItemRenderer
 		
 		int flip = hand == EnumHand.OFF_HAND ? -1 : 1;
 		
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		{
 			//Get the reload animation rotation
 			float reloadRotate = 0F;
@@ -84,38 +83,38 @@ public class RenderGun implements CustomItemRenderer
 				case ENTITY:
 				{
 					//EntityItem entity = (EntityItem)data[1];
-					//GL11.glRotatef(entity.getAge() + (entity.getAge() == 0 ? 0 : smoothing), 0F, 1F, 0F);
-					GL11.glTranslatef(-0.45F + model.itemFrameOffset.x, -0.05F + model.itemFrameOffset.y, model.itemFrameOffset.z);
+					//GlStateManager.rotate(entity.getAge() + (entity.getAge() == 0 ? 0 : smoothing), 0F, 1F, 0F);
+					GlStateManager.translate(-0.45F + model.itemFrameOffset.x, -0.05F + model.itemFrameOffset.y, model.itemFrameOffset.z);
 					break;
 				}
 				case INVENTORY:
 				{
-					GL11.glTranslatef(model.itemFrameOffset.x, model.itemFrameOffset.y, model.itemFrameOffset.z);
+					GlStateManager.translate(model.itemFrameOffset.x, model.itemFrameOffset.y, model.itemFrameOffset.z);
 					break;
 				}
 				case EQUIPPED:
 				{
 					if(hand == EnumHand.OFF_HAND)
 					{
-						GL11.glRotatef(-70F, 1F, 0F, 0F);
-						GL11.glRotatef(48F, 0F, 0F, 1F);
-						GL11.glRotatef(105F, 0F, 1F, 0F);
-						GL11.glTranslatef(-0.1F, -0.22F, -0.15F);
+						GlStateManager.rotate(-70F, 1F, 0F, 0F);
+						GlStateManager.rotate(48F, 0F, 0F, 1F);
+						GlStateManager.rotate(105F, 0F, 1F, 0F);
+						GlStateManager.translate(-0.1F, -0.22F, -0.15F);
 					}
 					else
 					{
-						GL11.glRotatef(90F, 0F, 0F, 1F);
-						GL11.glRotatef(-90F, 1F, 0F, 0F);
-						GL11.glTranslatef(0.2F, 0.05F, -0F);
-						GL11.glScalef(1F, 1F, -1F);
+						GlStateManager.rotate(90F, 0F, 0F, 1F);
+						GlStateManager.rotate(-90F, 1F, 0F, 0F);
+						GlStateManager.translate(0.2F, 0.05F, -0F);
+						GlStateManager.scale(1F, 1F, -1F);
 					}
-					GL11.glTranslatef(model.thirdPersonOffset.x, model.thirdPersonOffset.y, model.thirdPersonOffset.z);
+					GlStateManager.translate(model.thirdPersonOffset.x, model.thirdPersonOffset.y, model.thirdPersonOffset.z);
 					/*
 					if(animations.meleeAnimationProgress > 0 && animations.meleeAnimationProgress < gunType.meleePath.size()) 
 					{
 						Vector3f meleePos = gunType.meleePath.get(animations.meleeAnimationProgress);
 						Vector3f nextMeleePos = animations.meleeAnimationProgress + 1 < gunType.meleePath.size() ? gunType.meleePath.get(animations.meleeAnimationProgress + 1) : new Vector3f();
-						GL11.glTranslatef(meleePos.x + (nextMeleePos.x - meleePos.x) * smoothing, meleePos.y + (nextMeleePos.y - meleePos.y) * smoothing, meleePos.z + (nextMeleePos.z - meleePos.z) * smoothing);
+						GlStateManager.translate(meleePos.x + (nextMeleePos.x - meleePos.x) * smoothing, meleePos.y + (nextMeleePos.y - meleePos.y) * smoothing, meleePos.z + (nextMeleePos.z - meleePos.z) * smoothing);
 					}
 					*/
 					break;
@@ -125,38 +124,38 @@ public class RenderGun implements CustomItemRenderer
 					IScope scope = gunType.getCurrentScope(item);
 					if(FlansModClient.zoomProgress > 0.9F && scope.hasZoomOverlay())
 					{
-						GL11.glPopMatrix();
+						GlStateManager.popMatrix();
 						return;
 					}
 					float adsSwitch = FlansModClient.lastZoomProgress + (FlansModClient.zoomProgress - FlansModClient.lastZoomProgress) * smoothing;//0F;//((float)Math.sin((FlansMod.ticker) / 10F) + 1F) / 2F;
 					
 					if(hand == EnumHand.OFF_HAND)
 					{
-						GL11.glRotatef(45F, 0F, 1F, 0F);
-						GL11.glTranslatef(-1F, 0.675F, -1.8F);
+						GlStateManager.rotate(45F, 0F, 1F, 0F);
+						GlStateManager.translate(-1F, 0.675F, -1.8F);
 					}
 					else
 					{
-						GL11.glRotatef(45F, 0F, 1F, 0F);
-						GL11.glRotatef(0F - 5F * adsSwitch, 0F, 0F, 1F);
+						GlStateManager.rotate(45F, 0F, 1F, 0F);
+						GlStateManager.rotate(0F - 5F * adsSwitch, 0F, 0F, 1F);
 						
-						GL11.glTranslatef(-1F, 0.675F + 0.180F * adsSwitch, -1F - 0.395F * adsSwitch);
+						GlStateManager.translate(-1F, 0.675F + 0.180F * adsSwitch, -1F - 0.395F * adsSwitch);
 						if(gunType.hasScopeOverlay)
-							GL11.glTranslatef(-0.7F * adsSwitch, -0.12F * adsSwitch, -0.05F * adsSwitch);
-						GL11.glRotatef(4.5F * adsSwitch, 0F, 0F, 1F);
-						GL11.glTranslatef(0F, -0.03F * adsSwitch, 0F);
+							GlStateManager.translate(-0.7F * adsSwitch, -0.12F * adsSwitch, -0.05F * adsSwitch);
+						GlStateManager.rotate(4.5F * adsSwitch, 0F, 0F, 1F);
+						GlStateManager.translate(0F, -0.03F * adsSwitch, 0F);
 					}
 					
 					if(animations.meleeAnimationProgress > 0 && animations.meleeAnimationProgress < gunType.meleePath.size())
 					{
 						Vector3f meleePos = gunType.meleePath.get(animations.meleeAnimationProgress);
 						Vector3f nextMeleePos = animations.meleeAnimationProgress + 1 < gunType.meleePath.size() ? gunType.meleePath.get(animations.meleeAnimationProgress + 1) : new Vector3f();
-						GL11.glTranslatef(meleePos.x + (nextMeleePos.x - meleePos.x) * smoothing, meleePos.y + (nextMeleePos.y - meleePos.y) * smoothing, meleePos.z + (nextMeleePos.z - meleePos.z) * smoothing);
+						GlStateManager.translate(meleePos.x + (nextMeleePos.x - meleePos.x) * smoothing, meleePos.y + (nextMeleePos.y - meleePos.y) * smoothing, meleePos.z + (nextMeleePos.z - meleePos.z) * smoothing);
 						Vector3f meleeAngles = gunType.meleePathAngles.get(animations.meleeAnimationProgress);
 						Vector3f nextMeleeAngles = animations.meleeAnimationProgress + 1 < gunType.meleePathAngles.size() ? gunType.meleePathAngles.get(animations.meleeAnimationProgress + 1) : new Vector3f();
-						GL11.glRotatef(meleeAngles.y + (nextMeleeAngles.y - meleeAngles.y) * smoothing, 0F, 1F, 0F);
-						GL11.glRotatef(meleeAngles.z + (nextMeleeAngles.z - meleeAngles.z) * smoothing, 0F, 0F, 1F);
-						GL11.glRotatef(meleeAngles.x + (nextMeleeAngles.x - meleeAngles.x) * smoothing, 1F, 0F, 0F);
+						GlStateManager.rotate(meleeAngles.y + (nextMeleeAngles.y - meleeAngles.y) * smoothing, 0F, 1F, 0F);
+						GlStateManager.rotate(meleeAngles.z + (nextMeleeAngles.z - meleeAngles.z) * smoothing, 0F, 0F, 1F);
+						GlStateManager.rotate(meleeAngles.x + (nextMeleeAngles.x - meleeAngles.x) * smoothing, 1F, 0F, 0F);
 					}
 					
 					// Look at gun stuff
@@ -206,29 +205,29 @@ public class RenderGun implements CustomItemRenderer
 							break;
 					}
 					
-					GL11.glRotatef(startAngles.y + (endAngles.y - startAngles.y) * interp, 0f, 1f, 0f);
-					GL11.glRotatef(startAngles.z + (endAngles.z - startAngles.z) * interp, 0f, 0f, 1f);
-					GL11.glTranslatef(startPos.x + (endPos.x - startPos.x) * interp,
+					GlStateManager.rotate(startAngles.y + (endAngles.y - startAngles.y) * interp, 0f, 1f, 0f);
+					GlStateManager.rotate(startAngles.z + (endAngles.z - startAngles.z) * interp, 0f, 0f, 1f);
+					GlStateManager.translate(startPos.x + (endPos.x - startPos.x) * interp,
 							startPos.y + (endPos.y - startPos.y) * interp,
 							startPos.z + (endPos.z - startPos.z) * interp);
 					
 					
-					//GL11.glRotatef(70f, 0f, 1f, 0f);
-					//GL11.glTranslatef(0.25f, 0.25f, 0f);
+					//GlStateManager.rotate(70f, 0f, 1f, 0f);
+					//GlStateManager.translate(0.25f, 0.25f, 0f);
 					
-					//GL11.glRotatef(-60f, 0f, 1f, 0f);
-					//GL11.glRotatef(60f, 0f, 0f, 1f);
-					//GL11.glTranslatef(0.25f, 0.25f, -0.5f);
+					//GlStateManager.rotate(-60f, 0f, 1f, 0f);
+					//GlStateManager.rotate(60f, 0f, 0f, 1f);
+					//GlStateManager.translate(0.25f, 0.25f, -0.5f);
 					
-					GL11.glRotatef(-animations.recoilAngle * (float)Math.sqrt(gunType.recoil) * 1.5f, 0F, 0F, 1F);
-					GL11.glTranslatef(animations.recoilOffset.x, animations.recoilOffset.y, animations.recoilOffset.z);
+					GlStateManager.rotate(-animations.recoilAngle * (float)Math.sqrt(gunType.recoil) * 1.5f, 0F, 0F, 1F);
+					GlStateManager.translate(animations.recoilOffset.x, animations.recoilOffset.y, animations.recoilOffset.z);
 					
 					if(model.spinningCocking)
 					{
-						GL11.glTranslatef(model.spinPoint.x, model.spinPoint.y, model.spinPoint.z);
+						GlStateManager.translate(model.spinPoint.x, model.spinPoint.y, model.spinPoint.z);
 						float pumped = (animations.lastPumped + (animations.pumped - animations.lastPumped) * smoothing);
-						GL11.glRotatef(pumped * 180F + 180F, 0F, 0F, 1F);
-						GL11.glTranslatef(-model.spinPoint.x, -model.spinPoint.y, -model.spinPoint.z);
+						GlStateManager.rotate(pumped * 180F + 180F, 0F, 0F, 1F);
+						GlStateManager.translate(-model.spinPoint.x, -model.spinPoint.y, -model.spinPoint.z);
 					}
 					
 					if(animations.reloading)
@@ -246,65 +245,65 @@ public class RenderGun implements CustomItemRenderer
 						{
 							case BOTTOM_CLIP: case PISTOL_CLIP: case SHOTGUN: case END_LOADED:
 						{
-							GL11.glRotatef(60F * reloadRotate, 0F, 0F, 1F);
-							GL11.glRotatef(30F * reloadRotate * flip, 1F, 0F, 0F);
-							GL11.glTranslatef(0.25F * reloadRotate, 0F, 0F);
+							GlStateManager.rotate(60F * reloadRotate, 0F, 0F, 1F);
+							GlStateManager.rotate(30F * reloadRotate * flip, 1F, 0F, 0F);
+							GlStateManager.translate(0.25F * reloadRotate, 0F, 0F);
 							break;
 						}
 							case BACK_LOADED:
 							{
-								GL11.glRotatef(-75F * reloadRotate, 0F, 0F, 1F);
-								GL11.glRotatef(-30F * reloadRotate * flip, 1F, 0F, 0F);
-								GL11.glTranslatef(0.5F * reloadRotate, 0F, 0F);
+								GlStateManager.rotate(-75F * reloadRotate, 0F, 0F, 1F);
+								GlStateManager.rotate(-30F * reloadRotate * flip, 1F, 0F, 0F);
+								GlStateManager.translate(0.5F * reloadRotate, 0F, 0F);
 								break;
 							}
 							case BULLPUP:
 							{
-								GL11.glRotatef(70F * reloadRotate, 0F, 0F, 1F);
-								GL11.glRotatef(10F * reloadRotate * flip, 1F, 0F, 0F);
-								GL11.glTranslatef(0.5F * reloadRotate, -0.2F * reloadRotate, 0F);
+								GlStateManager.rotate(70F * reloadRotate, 0F, 0F, 1F);
+								GlStateManager.rotate(10F * reloadRotate * flip, 1F, 0F, 0F);
+								GlStateManager.translate(0.5F * reloadRotate, -0.2F * reloadRotate, 0F);
 								break;
 							}
 							case RIFLE:
 							{
-								GL11.glRotatef(30F * reloadRotate, 0F, 0F, 1F);
-								GL11.glRotatef(-30F * reloadRotate * flip, 1F, 0F, 0F);
-								GL11.glTranslatef(0.5F * reloadRotate, 0F, -0.5F * reloadRotate);
+								GlStateManager.rotate(30F * reloadRotate, 0F, 0F, 1F);
+								GlStateManager.rotate(-30F * reloadRotate * flip, 1F, 0F, 0F);
+								GlStateManager.translate(0.5F * reloadRotate, 0F, -0.5F * reloadRotate);
 								break;
 							}
 							case RIFLE_TOP: case REVOLVER:
 						{
-							GL11.glRotatef(30F * reloadRotate, 0F, 0F, 1F);
-							GL11.glRotatef(10F * reloadRotate, 0F, 1F, 0F);
-							GL11.glRotatef(-10F * reloadRotate * flip, 1F, 0F, 0F);
-							GL11.glTranslatef(0.1F * reloadRotate, -0.2F * reloadRotate, -0.1F * reloadRotate);
+							GlStateManager.rotate(30F * reloadRotate, 0F, 0F, 1F);
+							GlStateManager.rotate(10F * reloadRotate, 0F, 1F, 0F);
+							GlStateManager.rotate(-10F * reloadRotate * flip, 1F, 0F, 0F);
+							GlStateManager.translate(0.1F * reloadRotate, -0.2F * reloadRotate, -0.1F * reloadRotate);
 							break;
 						}
 							case ALT_PISTOL_CLIP:
 							{
-								GL11.glRotatef(60F * reloadRotate * flip, 0F, 1F, 0F);
-								GL11.glTranslatef(0.15F * reloadRotate, 0.25F * reloadRotate, 0F);
+								GlStateManager.rotate(60F * reloadRotate * flip, 0F, 1F, 0F);
+								GlStateManager.translate(0.15F * reloadRotate, 0.25F * reloadRotate, 0F);
 								break;
 							}
 							case STRIKER:
 							{
-								GL11.glRotatef(-35F * reloadRotate * flip, 1F, 0F, 0F);
-								GL11.glTranslatef(0.2F * reloadRotate, 0F, -0.1F * reloadRotate);
+								GlStateManager.rotate(-35F * reloadRotate * flip, 1F, 0F, 0F);
+								GlStateManager.translate(0.2F * reloadRotate, 0F, -0.1F * reloadRotate);
 								break;
 							}
 							case GENERIC:
 							{
 								//Gun reloads partly or completely off-screen.
-								GL11.glRotatef(45F * reloadRotate, 0F, 0F, 1F);
-								GL11.glTranslatef(-0.2F * reloadRotate, -0.5F * reloadRotate, 0F);
+								GlStateManager.rotate(45F * reloadRotate, 0F, 0F, 1F);
+								GlStateManager.translate(-0.2F * reloadRotate, -0.5F * reloadRotate, 0F);
 								break;
 							}
 							case CUSTOM:
 							{
-								GL11.glRotatef(model.rotateGunVertical * reloadRotate, 0F, 0F, 1F);
-								GL11.glRotatef(model.rotateGunHorizontal * reloadRotate, 0F, 1F, 0F);
-								GL11.glRotatef(model.tiltGun * reloadRotate, 1F, 0F, 0F);
-								GL11.glTranslatef(model.translateGun.x * reloadRotate, model.translateGun.y * reloadRotate, model.translateGun.z * reloadRotate);
+								GlStateManager.rotate(model.rotateGunVertical * reloadRotate, 0F, 0F, 1F);
+								GlStateManager.rotate(model.rotateGunHorizontal * reloadRotate, 0F, 1F, 0F);
+								GlStateManager.rotate(model.tiltGun * reloadRotate, 1F, 0F, 0F);
+								GlStateManager.translate(model.translateGun.x * reloadRotate, model.translateGun.y * reloadRotate, model.translateGun.z * reloadRotate);
 								break;
 							}
 							default: break;
@@ -317,7 +316,7 @@ public class RenderGun implements CustomItemRenderer
 			
 			renderGun(item, gunType, f, model, animations, reloadRotate);
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	/**
@@ -369,12 +368,12 @@ public class RenderGun implements CustomItemRenderer
 		}
 		
 		if(scopeAttachment != null)
-			GL11.glTranslatef(0F, -scopeAttachment.model.renderOffset / 16F, 0F);
+			GlStateManager.translate(0F, -scopeAttachment.model.renderOffset / 16F, 0F);
 		
 		//Render the gun and default attachment models
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		{
-			GL11.glScalef(type.modelScale, type.modelScale, type.modelScale);
+			GlStateManager.scale(type.modelScale, type.modelScale, type.modelScale);
 			
 			model.renderGun(f);
 			model.renderCustom(f, animations);
@@ -389,62 +388,62 @@ public class RenderGun implements CustomItemRenderer
 			
 			//Render various shoot / reload animated parts
 			//Render the slide
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
-				GL11.glTranslatef(-(animations.lastGunSlide + (animations.gunSlide - animations.lastGunSlide) * smoothing) * model.gunSlideDistance, 0F, 0F);
+				GlStateManager.translate(-(animations.lastGunSlide + (animations.gunSlide - animations.lastGunSlide) * smoothing) * model.gunSlideDistance, 0F, 0F);
 				model.renderSlide(f);
 				if(scopeAttachment == null && model.scopeIsOnSlide)
 					model.renderDefaultScope(f);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			//Render the break action
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
-				GL11.glTranslatef(model.barrelBreakPoint.x, model.barrelBreakPoint.y, model.barrelBreakPoint.z);
-				GL11.glRotatef(reloadRotate * -model.breakAngle, 0F, 0F, 1F);
-				GL11.glTranslatef(-model.barrelBreakPoint.x, -model.barrelBreakPoint.y, -model.barrelBreakPoint.z);
+				GlStateManager.translate(model.barrelBreakPoint.x, model.barrelBreakPoint.y, model.barrelBreakPoint.z);
+				GlStateManager.rotate(reloadRotate * -model.breakAngle, 0F, 0F, 1F);
+				GlStateManager.translate(-model.barrelBreakPoint.x, -model.barrelBreakPoint.y, -model.barrelBreakPoint.z);
 				model.renderBreakAction(f);
 				if(scopeAttachment == null && model.scopeIsOnBreakAction)
 					model.renderDefaultScope(f);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			//Render the pump-action handle
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
-				GL11.glTranslatef(-(1 - Math.abs(animations.lastPumped + (animations.pumped - animations.lastPumped) * smoothing)) * model.pumpHandleDistance, 0F, 0F);
+				GlStateManager.translate(-(1 - Math.abs(animations.lastPumped + (animations.pumped - animations.lastPumped) * smoothing)) * model.pumpHandleDistance, 0F, 0F);
 				model.renderPump(f);
 				if(gripAttachment == null && model.gripIsOnPump)
 					model.renderDefaultGrip(f);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			//Render the minigun barrels
 			if(type.mode == EnumFireMode.MINIGUN)
 			{
-				GL11.glPushMatrix();
-				GL11.glTranslatef(model.minigunBarrelOrigin.x, model.minigunBarrelOrigin.y, model.minigunBarrelOrigin.z);
-				GL11.glRotatef(animations.minigunBarrelRotation, 1F, 0F, 0F);
-				GL11.glTranslatef(-model.minigunBarrelOrigin.x, -model.minigunBarrelOrigin.y, -model.minigunBarrelOrigin.z);
+				GlStateManager.pushMatrix();
+				GlStateManager.translate(model.minigunBarrelOrigin.x, model.minigunBarrelOrigin.y, model.minigunBarrelOrigin.z);
+				GlStateManager.rotate(animations.minigunBarrelRotation, 1F, 0F, 0F);
+				GlStateManager.translate(-model.minigunBarrelOrigin.x, -model.minigunBarrelOrigin.y, -model.minigunBarrelOrigin.z);
 				model.renderMinigunBarrel(f);
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 			}
 			
 			//Render the cocking handle
 			
 			//Render the revolver barrel
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
-				GL11.glTranslatef(model.revolverFlipPoint.x, model.revolverFlipPoint.y, model.revolverFlipPoint.z);
-				GL11.glRotatef(reloadRotate * model.revolverFlipAngle, 1F, 0F, 0F);
-				GL11.glTranslatef(-model.revolverFlipPoint.x, -model.revolverFlipPoint.y, -model.revolverFlipPoint.z);
+				GlStateManager.translate(model.revolverFlipPoint.x, model.revolverFlipPoint.y, model.revolverFlipPoint.z);
+				GlStateManager.rotate(reloadRotate * model.revolverFlipAngle, 1F, 0F, 0F);
+				GlStateManager.translate(-model.revolverFlipPoint.x, -model.revolverFlipPoint.y, -model.revolverFlipPoint.z);
 				model.renderRevolverBarrel(f);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			//Render the clip
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
 				boolean shouldRender = true;
 				//Check to see if the ammo should be rendered first
@@ -476,58 +475,58 @@ public class RenderGun implements CustomItemRenderer
 					{
 						case BREAK_ACTION:
 						{
-							GL11.glTranslatef(model.barrelBreakPoint.x, model.barrelBreakPoint.y, model.barrelBreakPoint.z);
-							GL11.glRotatef(reloadRotate * -model.breakAngle, 0F, 0F, 1F);
-							GL11.glTranslatef(-model.barrelBreakPoint.x, -model.barrelBreakPoint.y, -model.barrelBreakPoint.z);
-							GL11.glTranslatef(-1F * clipPosition, 0F, 0F);
+							GlStateManager.translate(model.barrelBreakPoint.x, model.barrelBreakPoint.y, model.barrelBreakPoint.z);
+							GlStateManager.rotate(reloadRotate * -model.breakAngle, 0F, 0F, 1F);
+							GlStateManager.translate(-model.barrelBreakPoint.x, -model.barrelBreakPoint.y, -model.barrelBreakPoint.z);
+							GlStateManager.translate(-1F * clipPosition, 0F, 0F);
 							break;
 						}
 						case REVOLVER:
 						{
-							GL11.glTranslatef(model.revolverFlipPoint.x, model.revolverFlipPoint.y, model.revolverFlipPoint.z);
-							GL11.glRotatef(reloadRotate * model.revolverFlipAngle, 1F, 0F, 0F);
-							GL11.glTranslatef(-model.revolverFlipPoint.x, -model.revolverFlipPoint.y, -model.revolverFlipPoint.z);
-							GL11.glTranslatef(-1F * clipPosition, 0F, 0F);
+							GlStateManager.translate(model.revolverFlipPoint.x, model.revolverFlipPoint.y, model.revolverFlipPoint.z);
+							GlStateManager.rotate(reloadRotate * model.revolverFlipAngle, 1F, 0F, 0F);
+							GlStateManager.translate(-model.revolverFlipPoint.x, -model.revolverFlipPoint.y, -model.revolverFlipPoint.z);
+							GlStateManager.translate(-1F * clipPosition, 0F, 0F);
 							break;
 						}
 						case BOTTOM_CLIP:
 						{
-							GL11.glRotatef(-180F * clipPosition, 0F, 0F, 1F);
-							GL11.glRotatef(60F * clipPosition, 1F, 0F, 0F);
-							GL11.glTranslatef(0.5F * clipPosition, 0F, 0F);
+							GlStateManager.rotate(-180F * clipPosition, 0F, 0F, 1F);
+							GlStateManager.rotate(60F * clipPosition, 1F, 0F, 0F);
+							GlStateManager.translate(0.5F * clipPosition, 0F, 0F);
 							break;
 						}
 						case PISTOL_CLIP:
 						{
-							GL11.glRotatef(-90F * clipPosition * clipPosition, 0F, 0F, 1F);
-							GL11.glTranslatef(0F, -1F * clipPosition, 0F);
+							GlStateManager.rotate(-90F * clipPosition * clipPosition, 0F, 0F, 1F);
+							GlStateManager.translate(0F, -1F * clipPosition, 0F);
 							break;
 						}
 						case ALT_PISTOL_CLIP:
 						{
-							GL11.glRotatef(5F * clipPosition, 0F, 0F, 1F);
-							GL11.glTranslatef(0F, -3F * clipPosition, 0F);
+							GlStateManager.rotate(5F * clipPosition, 0F, 0F, 1F);
+							GlStateManager.translate(0F, -3F * clipPosition, 0F);
 							break;
 						}
 						case SIDE_CLIP:
 						{
-							GL11.glRotatef(180F * clipPosition, 0F, 1F, 0F);
-							GL11.glRotatef(60F * clipPosition, 0F, 1F, 0F);
-							GL11.glTranslatef(0.5F * clipPosition, 0F, 0F);
+							GlStateManager.rotate(180F * clipPosition, 0F, 1F, 0F);
+							GlStateManager.rotate(60F * clipPosition, 0F, 1F, 0F);
+							GlStateManager.translate(0.5F * clipPosition, 0F, 0F);
 							break;
 						}
 						case BULLPUP:
 						{
-							GL11.glRotatef(-150F * clipPosition, 0F, 0F, 1F);
-							GL11.glRotatef(60F * clipPosition, 1F, 0F, 0F);
-							GL11.glTranslatef(1F * clipPosition, -0.5F * clipPosition, 0F);
+							GlStateManager.rotate(-150F * clipPosition, 0F, 0F, 1F);
+							GlStateManager.rotate(60F * clipPosition, 1F, 0F, 0F);
+							GlStateManager.translate(1F * clipPosition, -0.5F * clipPosition, 0F);
 							break;
 						}
 						case P90:
 						{
-							GL11.glRotatef(-15F * reloadRotate * reloadRotate, 0F, 0F, 1F);
-							GL11.glTranslatef(0F, 0.075F * reloadRotate, 0F);
-							GL11.glTranslatef(-2F * clipPosition, -0.3F * clipPosition, 0.5F * clipPosition);
+							GlStateManager.rotate(-15F * reloadRotate * reloadRotate, 0F, 0F, 1F);
+							GlStateManager.translate(0F, 0.075F * reloadRotate, 0F);
+							GlStateManager.translate(-2F * clipPosition, -0.3F * clipPosition, 0.5F * clipPosition);
 							break;
 						}
 						case RIFLE:
@@ -536,9 +535,9 @@ public class RenderGun implements CustomItemRenderer
 							int bulletNum = MathHelper.floor(thing);
 							float bulletProgress = thing - bulletNum;
 							
-							GL11.glRotatef(bulletProgress * 15F, 0F, 1F, 0F);
-							GL11.glRotatef(bulletProgress * 15F, 0F, 0F, 1F);
-							GL11.glTranslatef(bulletProgress * -1F, 0F, bulletProgress * 0.5F);
+							GlStateManager.rotate(bulletProgress * 15F, 0F, 1F, 0F);
+							GlStateManager.rotate(bulletProgress * 15F, 0F, 0F, 1F);
+							GlStateManager.translate(bulletProgress * -1F, 0F, bulletProgress * 0.5F);
 							
 							break;
 						}
@@ -548,9 +547,9 @@ public class RenderGun implements CustomItemRenderer
 							int bulletNum = MathHelper.floor(thing);
 							float bulletProgress = thing - bulletNum;
 							
-							GL11.glRotatef(bulletProgress * 55F, 0F, 1F, 0F);
-							GL11.glRotatef(bulletProgress * 95F, 0F, 0F, 1F);
-							GL11.glTranslatef(bulletProgress * -0.1F, bulletProgress * 1F, bulletProgress * 0.5F);
+							GlStateManager.rotate(bulletProgress * 55F, 0F, 1F, 0F);
+							GlStateManager.rotate(bulletProgress * 95F, 0F, 0F, 1F);
+							GlStateManager.translate(bulletProgress * -0.1F, bulletProgress * 1F, bulletProgress * 0.5F);
 							
 							break;
 						}
@@ -560,17 +559,17 @@ public class RenderGun implements CustomItemRenderer
 						int bulletNum = MathHelper.floor(thing);
 						float bulletProgress = thing - bulletNum;
 						
-						GL11.glRotatef(bulletProgress * -30F, 0F, 0F, 1F);
-						GL11.glTranslatef(bulletProgress * -0.5F, bulletProgress * -1F, 0F);
+						GlStateManager.rotate(bulletProgress * -30F, 0F, 0F, 1F);
+						GlStateManager.translate(bulletProgress * -0.5F, bulletProgress * -1F, 0F);
 						
 						break;
 					}
 						case CUSTOM:
 						{
-							GL11.glRotatef(model.rotateClipVertical * clipPosition, 0F, 0F, 1F);
-							GL11.glRotatef(model.rotateClipHorizontal * clipPosition, 0F, 1F, 0F);
-							GL11.glRotatef(model.tiltClip * clipPosition, 1F, 0F, 0F);
-							GL11.glTranslatef(model.translateClip.x * clipPosition, model.translateClip.y * clipPosition, model.translateClip.z * clipPosition);
+							GlStateManager.rotate(model.rotateClipVertical * clipPosition, 0F, 0F, 1F);
+							GlStateManager.rotate(model.rotateClipHorizontal * clipPosition, 0F, 1F, 0F);
+							GlStateManager.rotate(model.tiltClip * clipPosition, 1F, 0F, 0F);
+							GlStateManager.translate(model.translateClip.x * clipPosition, model.translateClip.y * clipPosition, model.translateClip.z * clipPosition);
 							break;
 						}
 						case END_LOADED:
@@ -583,21 +582,21 @@ public class RenderGun implements CustomItemRenderer
 							float dYaw = (loadOnlyClipPosition > 0.5F ? loadOnlyClipPosition * 2F - 1F : 0F);
 							
 							
-							GL11.glRotatef(-45F * dYaw, 0F, 0F, 1F);
-							GL11.glTranslatef(-model.endLoadedAmmoDistance * dYaw, -0.5F * dYaw, 0F);
+							GlStateManager.rotate(-45F * dYaw, 0F, 0F, 1F);
+							GlStateManager.translate(-model.endLoadedAmmoDistance * dYaw, -0.5F * dYaw, 0F);
 							
 							float xDisplacement = (loadOnlyClipPosition < 0.5F ? loadOnlyClipPosition * 2F : 1F);
 							
-							GL11.glTranslatef(model.endLoadedAmmoDistance * xDisplacement, 0F, 0F);
+							GlStateManager.translate(model.endLoadedAmmoDistance * xDisplacement, 0F, 0F);
 							
 							/*
-							GL11.glTranslatef(1F * bulletProgress, -3F * bulletProgress, 0F);
+							GlStateManager.translate(1F * bulletProgress, -3F * bulletProgress, 0F);
 							if(bulletProgress > 0.5F)
-								GL11.glRotatef(-90F * (bulletProgress * 2F), 0F, 0F, 1F);	
+								GlStateManager.rotate(-90F * (bulletProgress * 2F), 0F, 0F, 1F);	
 							
 							if(bulletProgress < 0.5F)
 							{
-								GL11.glTranslatef(-3F * (bulletProgress - 0.5F), 0F, 0F);
+								GlStateManager.translate(-3F * (bulletProgress - 0.5F), 0F, 0F);
 								
 							}
 							*/
@@ -610,12 +609,12 @@ public class RenderGun implements CustomItemRenderer
 							float dYaw = (loadOnlyClipPosition > 0.5F ? loadOnlyClipPosition * 2F - 1F : 0F);
 							
 							
-							//GL11.glRotatef(-45F * dYaw, 0F, 0F, 1F);
-							GL11.glTranslatef(model.endLoadedAmmoDistance * dYaw, -0.5F * dYaw, 0F);
+							//GlStateManager.rotate(-45F * dYaw, 0F, 0F, 1F);
+							GlStateManager.translate(model.endLoadedAmmoDistance * dYaw, -0.5F * dYaw, 0F);
 							
 							float xDisplacement = (loadOnlyClipPosition < 0.5F ? loadOnlyClipPosition * 2F : 1F);
 							
-							GL11.glTranslatef(-model.endLoadedAmmoDistance * xDisplacement, 0F, 0F);
+							GlStateManager.translate(-model.endLoadedAmmoDistance * xDisplacement, 0F, 0F);
 						}
 						
 						default: break;
@@ -625,88 +624,88 @@ public class RenderGun implements CustomItemRenderer
 				if(shouldRender)
 					model.renderAmmo(f);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 		
 		//Render static attachments
 		//Scope
 		if(scopeAttachment != null)
 		{
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
 				Paintjob scopepaintjob = scopeAttachment.getPaintjob(scopeItemStack.getItemDamage());
 				renderEngine.bindTexture(FlansModResourceHandler.getPaintjobTexture(scopepaintjob));
 				if(model.scopeIsOnBreakAction)
 				{
-					GL11.glTranslatef(model.barrelBreakPoint.x, model.barrelBreakPoint.y, model.barrelBreakPoint.z);
-					GL11.glRotatef(reloadRotate * -model.breakAngle, 0F, 0F, 1F);
-					GL11.glTranslatef(-model.barrelBreakPoint.x, -model.barrelBreakPoint.y, -model.barrelBreakPoint.z);
+					GlStateManager.translate(model.barrelBreakPoint.x, model.barrelBreakPoint.y, model.barrelBreakPoint.z);
+					GlStateManager.rotate(reloadRotate * -model.breakAngle, 0F, 0F, 1F);
+					GlStateManager.translate(-model.barrelBreakPoint.x, -model.barrelBreakPoint.y, -model.barrelBreakPoint.z);
 				}
-				GL11.glTranslatef(model.scopeAttachPoint.x * type.modelScale, model.scopeAttachPoint.y * type.modelScale, model.scopeAttachPoint.z * type.modelScale);
+				GlStateManager.translate(model.scopeAttachPoint.x * type.modelScale, model.scopeAttachPoint.y * type.modelScale, model.scopeAttachPoint.z * type.modelScale);
 				
 				if(model.scopeIsOnSlide)
-					GL11.glTranslatef(-(animations.lastGunSlide + (animations.gunSlide - animations.lastGunSlide) * smoothing) * model.gunSlideDistance, 0F, 0F);
-				GL11.glScalef(scopeAttachment.modelScale, scopeAttachment.modelScale, scopeAttachment.modelScale);
+					GlStateManager.translate(-(animations.lastGunSlide + (animations.gunSlide - animations.lastGunSlide) * smoothing) * model.gunSlideDistance, 0F, 0F);
+				GlStateManager.scale(scopeAttachment.modelScale, scopeAttachment.modelScale, scopeAttachment.modelScale);
 				ModelAttachment scopeModel = scopeAttachment.model;
 				if(scopeModel != null)
 					scopeModel.renderAttachment(f);
 				renderEngine.bindTexture(FlansModResourceHandler.getTexture(type));
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 		//Grip
 		if(gripAttachment != null)
 		{
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
 				Paintjob grippaintjob = gripAttachment.getPaintjob(gripItemStack.getItemDamage());
 				renderEngine.bindTexture(FlansModResourceHandler.getPaintjobTexture(grippaintjob));
-				GL11.glTranslatef(model.gripAttachPoint.x * type.modelScale, model.gripAttachPoint.y * type.modelScale, model.gripAttachPoint.z * type.modelScale);
+				GlStateManager.translate(model.gripAttachPoint.x * type.modelScale, model.gripAttachPoint.y * type.modelScale, model.gripAttachPoint.z * type.modelScale);
 				if(model.gripIsOnPump)
-					GL11.glTranslatef(-(1 - Math.abs(animations.lastPumped + (animations.pumped - animations.lastPumped) * smoothing)) * model.pumpHandleDistance, 0F, 0F);
-				GL11.glScalef(gripAttachment.modelScale, gripAttachment.modelScale, gripAttachment.modelScale);
+					GlStateManager.translate(-(1 - Math.abs(animations.lastPumped + (animations.pumped - animations.lastPumped) * smoothing)) * model.pumpHandleDistance, 0F, 0F);
+				GlStateManager.scale(gripAttachment.modelScale, gripAttachment.modelScale, gripAttachment.modelScale);
 				ModelAttachment gripModel = gripAttachment.model;
 				if(gripModel != null)
 					gripModel.renderAttachment(f);
 				renderEngine.bindTexture(FlansModResourceHandler.getTexture(type));
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 		//Barrel
 		if(barrelAttachment != null)
 		{
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
 				Paintjob barrelpaintjob = barrelAttachment.getPaintjob(barrelItemStack.getItemDamage());
 				renderEngine.bindTexture(FlansModResourceHandler.getPaintjobTexture(barrelpaintjob));
-				GL11.glTranslatef(model.barrelAttachPoint.x * type.modelScale, model.barrelAttachPoint.y * type.modelScale, model.barrelAttachPoint.z * type.modelScale);
-				GL11.glScalef(barrelAttachment.modelScale, barrelAttachment.modelScale, barrelAttachment.modelScale);
+				GlStateManager.translate(model.barrelAttachPoint.x * type.modelScale, model.barrelAttachPoint.y * type.modelScale, model.barrelAttachPoint.z * type.modelScale);
+				GlStateManager.scale(barrelAttachment.modelScale, barrelAttachment.modelScale, barrelAttachment.modelScale);
 				ModelAttachment barrelModel = barrelAttachment.model;
 				if(barrelModel != null)
 					barrelModel.renderAttachment(f);
 				renderEngine.bindTexture(FlansModResourceHandler.getTexture(type));
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 		//Stock
 		if(stockAttachment != null)
 		{
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
 				Paintjob stockpaintjob = stockAttachment.getPaintjob(stockItemStack.getItemDamage());
 				renderEngine.bindTexture(FlansModResourceHandler.getPaintjobTexture(stockpaintjob));
-				GL11.glTranslatef(model.stockAttachPoint.x * type.modelScale, model.stockAttachPoint.y * type.modelScale, model.stockAttachPoint.z * type.modelScale);
-				GL11.glScalef(stockAttachment.modelScale, stockAttachment.modelScale, stockAttachment.modelScale);
+				GlStateManager.translate(model.stockAttachPoint.x * type.modelScale, model.stockAttachPoint.y * type.modelScale, model.stockAttachPoint.z * type.modelScale);
+				GlStateManager.scale(stockAttachment.modelScale, stockAttachment.modelScale, stockAttachment.modelScale);
 				ModelAttachment stockModel = stockAttachment.model;
 				if(stockModel != null)
 					stockModel.renderAttachment(f);
 				renderEngine.bindTexture(FlansModResourceHandler.getTexture(type));
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 	}
 }

--- a/src/main/java/com/flansmod/client/model/RenderMG.java
+++ b/src/main/java/com/flansmod/client/model/RenderMG.java
@@ -1,7 +1,6 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -22,18 +21,18 @@ public class RenderMG extends Render<EntityMG>
 	public void doRender(EntityMG mg, double d, double d1, double d2, float f, float f1)
 	{
 		bindEntityTexture(mg);
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
 		
-		GL11.glRotatef(180F - mg.direction * 90F, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(180F - mg.direction * 90F, 0.0F, 1.0F, 0.0F);
 		ModelMG model = mg.type.deployableModel;
 		if(model == null)
 			return;
-		//GL11.glScalef(-1F, -1F, 1.0F);
+		//GlStateManager.scale(-1F, -1F, 1.0F);
 		model.renderBipod(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, mg);
-		GL11.glRotatef(-(mg.prevRotationYaw + (mg.rotationYaw - mg.prevRotationYaw) * f1), 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(-(mg.prevRotationYaw + (mg.rotationYaw - mg.prevRotationYaw) * f1), 0.0F, 1.0F, 0.0F);
 		model.renderGun(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, f1, mg);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/model/RenderMecha.java
+++ b/src/main/java/com/flansmod/client/model/RenderMecha.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -53,8 +54,8 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 		bindEntityTexture(mecha);
 		float scale = 1F / 16F;
 		MechaType type = mecha.getMechaType();
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d, (float)d1, (float)d2);
 		float dYaw = (mecha.axes.getYaw() - mecha.prevRotationYaw);
 		for(; dYaw > 180F; dYaw -= 360F)
 		{
@@ -76,16 +77,16 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 		for(; dRoll <= -180F; dRoll += 360F)
 		{
 		}
-		GL11.glRotatef(-mecha.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
-		GL11.glRotatef(mecha.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
-		GL11.glRotatef(mecha.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
+		GlStateManager.rotate(-mecha.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(mecha.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
+		GlStateManager.rotate(mecha.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
 		float modelScale = mecha.getMechaType().modelScale;
 		ModelMecha model = (ModelMecha)type.model;
 		
 		//Body Render
 		{
-			GL11.glPushMatrix();
-			GL11.glScalef(modelScale, modelScale, modelScale);
+			GlStateManager.pushMatrix();
+			GlStateManager.scale(modelScale, modelScale, modelScale);
 			if(model != null)
 				model.render(mecha, f1);
 			
@@ -96,22 +97,22 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 				MechaItemType hipsAddon = ((ItemMechaAddon)hipsSlot.getItem()).type;
 				if(hipsAddon.model != null)
 				{
-					GL11.glTranslatef(model.hipsAttachmentPoint.x, model.hipsAttachmentPoint.y, model.hipsAttachmentPoint.z);
-					GL11.glScalef(type.heldItemScale, type.heldItemScale, type.heldItemScale);
+					GlStateManager.translate(model.hipsAttachmentPoint.x, model.hipsAttachmentPoint.y, model.hipsAttachmentPoint.z);
+					GlStateManager.scale(type.heldItemScale, type.heldItemScale, type.heldItemScale);
 					if(hipsAddon.texture != null)
 						bindTexture(FlansModResourceHandler.getTexture(hipsAddon));
 					hipsAddon.model.render(mecha, f1);
 				}
 			}
 			
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 		//Left arm render
 		if(mecha.isPartIntact(EnumDriveablePart.leftArm))
 		{
 			bindEntityTexture(mecha);
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			
 			//Get the arm pitch from the mecha entity
 			float smoothedPitch = 0F;
@@ -126,34 +127,34 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 				smoothedPitch = -type.upperArmLimit;
 			
 			//Translate to the arm origin, rotate and render
-			GL11.glTranslatef(type.leftArmOrigin.x, mecha.getMechaType().leftArmOrigin.y, mecha.getMechaType().leftArmOrigin.z);
-			GL11.glRotatef(90F - smoothedPitch, 0F, 0F, 1F);
-			GL11.glPushMatrix();
-			GL11.glScalef(modelScale, modelScale, modelScale);
+			GlStateManager.translate(type.leftArmOrigin.x, mecha.getMechaType().leftArmOrigin.y, mecha.getMechaType().leftArmOrigin.z);
+			GlStateManager.rotate(90F - smoothedPitch, 0F, 0F, 1F);
+			GlStateManager.pushMatrix();
+			GlStateManager.scale(modelScale, modelScale, modelScale);
 			model.renderLeftArm(scale, mecha, f1);
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			//Move to the end of the arm and render the held item
-			GL11.glTranslatef(0F + type.leftHandModifierY, -type.armLength - type.leftHandModifierX, 0F + type.leftHandModifierZ);
+			GlStateManager.translate(0F + type.leftHandModifierY, -type.armLength - type.leftHandModifierX, 0F + type.leftHandModifierZ);
 			ItemStack holdingStack = mecha.inventory.getStackInSlot(EnumMechaSlotType.leftTool);
-			GL11.glScalef(modelScale, modelScale, modelScale);
+			GlStateManager.scale(modelScale, modelScale, modelScale);
 			if(holdingStack == null || holdingStack.isEmpty())
 			{
 				model.renderLeftHand(scale, mecha, f1);
 			}
 			else
 			{
-				GL11.glScalef(type.heldItemScale, type.heldItemScale, type.heldItemScale);
+				GlStateManager.scale(type.heldItemScale, type.heldItemScale, type.heldItemScale);
 				renderItem(mecha, holdingStack, 0, true, f1);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 		//Right arm render
 		if(mecha.isPartIntact(EnumDriveablePart.rightArm))
 		{
 			bindEntityTexture(mecha);
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			
 			//Get the arm pitch from the mecha entity
 			float smoothedPitch = 0F;
@@ -168,16 +169,16 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 				smoothedPitch = -type.upperArmLimit;
 			
 			//Translate to the arm origin, rotate and render
-			GL11.glTranslatef(type.rightArmOrigin.x, mecha.getMechaType().rightArmOrigin.y, mecha.getMechaType().rightArmOrigin.z);
-			GL11.glRotatef(90F - smoothedPitch, 0F, 0F, 1F);
-			GL11.glPushMatrix();
-			GL11.glScalef(modelScale, modelScale, modelScale);
+			GlStateManager.translate(type.rightArmOrigin.x, mecha.getMechaType().rightArmOrigin.y, mecha.getMechaType().rightArmOrigin.z);
+			GlStateManager.rotate(90F - smoothedPitch, 0F, 0F, 1F);
+			GlStateManager.pushMatrix();
+			GlStateManager.scale(modelScale, modelScale, modelScale);
 			model.renderRightArm(scale, mecha, f1);
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			//Move to the end of the arm and render the held item
-			GL11.glTranslatef(0F + type.rightHandModifierY, -type.armLength - type.rightHandModifierX, 0F + type.rightHandModifierZ);
-			GL11.glScalef(modelScale, modelScale, modelScale);
+			GlStateManager.translate(0F + type.rightHandModifierY, -type.armLength - type.rightHandModifierX, 0F + type.rightHandModifierZ);
+			GlStateManager.scale(modelScale, modelScale, modelScale);
 			ItemStack holdingStack = mecha.inventory.getStackInSlot(EnumMechaSlotType.rightTool);
 			if(holdingStack == null || holdingStack.isEmpty())
 			{
@@ -185,21 +186,21 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 			}
 			else
 			{
-				GL11.glScalef(type.heldItemScale, type.heldItemScale, type.heldItemScale);
+				GlStateManager.scale(type.heldItemScale, type.heldItemScale, type.heldItemScale);
 				renderItem(mecha, holdingStack, 0, false, f1);
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		
 		//Debug rendering
 		if(FlansMod.DEBUG)
 		{
-			GL11.glDisable(GL11.GL_TEXTURE_2D);
-			GL11.glEnable(GL11.GL_BLEND);
+			GlStateManager.disableTexture2D();
+			GlStateManager.enableBlend();
 			GL11.glDisable(GL11.GL_DEPTH_TEST);
 			
 			//Render boxes
-			GL11.glColor4f(1F, 0F, 0F, 0.3F);
+			GlStateManager.color(1F, 0F, 0F, 0.3F);
 			for(DriveablePart part : mecha.getDriveableData().parts.values())
 			{
 				if(part.box == null)
@@ -209,7 +210,7 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 			}
 			
 			//Render shoot points
-			GL11.glColor4f(0F, 0F, 1F, 0.3F);
+			GlStateManager.color(0F, 0F, 1F, 0.3F);
 			for(ShootPoint point : type.shootPointsPrimary)
 			{
 				DriveablePosition driveablePosition = point.rootPos;
@@ -223,7 +224,7 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 					0, 0, 0);
 			}
 			
-			GL11.glColor4f(0F, 1F, 0F, 0.3F);
+			GlStateManager.color(0F, 1F, 0F, 0.3F);
 			for(ShootPoint point : type.shootPointsSecondary)
 			{
 				DriveablePosition driveablePosition = point.rootPos;
@@ -237,19 +238,19 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 					0, 0, 0);
 			}
 			
-			GL11.glEnable(GL11.GL_TEXTURE_2D);
+			GlStateManager.enableTexture2D();
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
-			GL11.glDisable(GL11.GL_BLEND);
-			GL11.glColor4f(1F, 1F, 1F, 1F);
+			GlStateManager.disableBlend();
+			GlStateManager.color(1F, 1F, 1F, 1F);
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 		
 		//Leg render
 		if(mecha.isPartIntact(EnumDriveablePart.hips))
 		{
 			bindEntityTexture(mecha);
-			GL11.glPushMatrix();
-			GL11.glTranslatef((float)d, (float)d1, (float)d2);
+			GlStateManager.pushMatrix();
+			GlStateManager.translate((float)d, (float)d1, (float)d2);
 			dYaw = mecha.legAxes.getYaw() - mecha.prevLegsYaw;
 			for(; dYaw > 180F; dYaw -= 360F)
 			{
@@ -257,10 +258,10 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 			for(; dYaw <= -180F; dYaw += 360F)
 			{
 			}
-			GL11.glRotatef(-dYaw * f1 - mecha.prevLegsYaw, 0F, 1F, 0F);
-			GL11.glRotatef(mecha.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
-			GL11.glRotatef(mecha.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
-			GL11.glScalef(modelScale, modelScale, modelScale);
+			GlStateManager.rotate(-dYaw * f1 - mecha.prevLegsYaw, 0F, 1F, 0F);
+			GlStateManager.rotate(mecha.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
+			GlStateManager.rotate(mecha.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
+			GlStateManager.scale(modelScale, modelScale, modelScale);
 			if(model != null)
 			{
 				float legLength = type.legLength;
@@ -281,104 +282,104 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 				//Hips
 				model.renderHips(scale, mecha, f1);
 				
-				GL11.glPushMatrix();
+				GlStateManager.pushMatrix();
 				{
-					GL11.glTranslatef(legTrans, legLength, 0F);
+					GlStateManager.translate(legTrans, legLength, 0F);
 					
 					//Left Foot
-					GL11.glPushMatrix();
-					GL11.glTranslatef(footH, -footV, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.translate(footH, -footV, 0F);
 					model.renderLeftFoot(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Right Foot
-					GL11.glPushMatrix();
-					GL11.glTranslatef(-footH, -footV, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.translate(-footH, -footV, 0F);
 					model.renderRightFoot(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Left Leg
-					GL11.glPushMatrix();
-					GL11.glRotatef(legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
-					GL11.glTranslatef(0F, -legLength, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.rotate(legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
+					GlStateManager.translate(0F, -legLength, 0F);
 					model.renderLeftLeg(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Right Leg
-					GL11.glPushMatrix();
-					GL11.glRotatef(-legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
-					GL11.glTranslatef(0F, -legLength, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.rotate(-legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
+					GlStateManager.translate(0F, -legLength, 0F);
 					model.renderRightLeg(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 				}
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 				
-				GL11.glPushMatrix();
+				GlStateManager.pushMatrix();
 				{
-					GL11.glTranslatef(rearlegTrans, rearlegLength, 0F);
+					GlStateManager.translate(rearlegTrans, rearlegLength, 0F);
 					
 					//Left Rear Foot
-					GL11.glPushMatrix();
-					GL11.glTranslatef(-footRH, -footRV, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.translate(-footRH, -footRV, 0F);
 					model.renderLeftRearFoot(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Right Rear Foot
-					GL11.glPushMatrix();
-					GL11.glTranslatef(footRH, -footRV, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.translate(footRH, -footRV, 0F);
 					model.renderRightRearFoot(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Left Rear Leg
-					GL11.glPushMatrix();
-					GL11.glRotatef(-legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
-					GL11.glTranslatef(0F, -rearlegLength, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.rotate(-legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
+					GlStateManager.translate(0F, -rearlegLength, 0F);
 					model.renderLeftRearLeg(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Right Leg
-					GL11.glPushMatrix();
-					GL11.glRotatef(legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
-					GL11.glTranslatef(0F, -rearlegLength, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.rotate(legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
+					GlStateManager.translate(0F, -rearlegLength, 0F);
 					model.renderRightRearLeg(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 				}
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 				
-				GL11.glPushMatrix();
+				GlStateManager.pushMatrix();
 				{
-					GL11.glTranslatef(frontlegTrans, frontlegLength, 0F);
+					GlStateManager.translate(frontlegTrans, frontlegLength, 0F);
 					
 					//Left Front Foot
-					GL11.glPushMatrix();
-					GL11.glTranslatef(-footFH, -footFV, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.translate(-footFH, -footFV, 0F);
 					model.renderLeftFrontFoot(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Right Front Foot
-					GL11.glPushMatrix();
-					GL11.glTranslatef(footFH, -footFV, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.translate(footFH, -footFV, 0F);
 					model.renderRightFrontFoot(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Left Front Leg
-					GL11.glPushMatrix();
-					GL11.glRotatef(-legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
-					GL11.glTranslatef(0F, -frontlegLength, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.rotate(-legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
+					GlStateManager.translate(0F, -frontlegLength, 0F);
 					model.renderLeftFrontLeg(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 					
 					//Right Front Leg
-					GL11.glPushMatrix();
-					GL11.glRotatef(legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
-					GL11.glTranslatef(0F, -frontlegLength, 0F);
+					GlStateManager.pushMatrix();
+					GlStateManager.rotate(legsYaw * 180F / 3.14159265F, 0F, 0F, 1F);
+					GlStateManager.translate(0F, -frontlegLength, 0F);
 					model.renderRightFrontLeg(scale, mecha, f1);
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 				}
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 				
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 	}
 	
@@ -392,7 +393,7 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 	
 	private void renderItem(EntityMecha mecha, ItemStack stack, int par3, boolean leftHand, float dT)
 	{
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		TextureManager texturemanager = Minecraft.getMinecraft().getTextureManager();
 		Item item = stack.getItem();
 		
@@ -400,21 +401,21 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 		if(item instanceof ItemMechaAddon)
 		{
 			
-			GL11.glRotatef(-90F, 0F, 0F, 1F);
-			GL11.glTranslatef(0F, 0F, 0F);
+			GlStateManager.rotate(-90F, 0F, 0F, 1F);
+			GlStateManager.translate(0F, 0F, 0F);
 			ItemMechaAddon toolItem = (ItemMechaAddon)item;
 			MechaItemType toolType = toolItem.type;
 			bindTexture(FlansModResourceHandler.getTexture(toolType));
 			if(toolType.model != null)
 			{
 				toolType.model.render(mecha, dT);
-				GL11.glPushMatrix();
+				GlStateManager.pushMatrix();
 				if((leftHand && mecha.primaryShootHeld) || (!leftHand && mecha.secondaryShootHeld))
 				{
-					GL11.glRotatef(25F * (float)mecha.ticksExisted, 1F, 0F, 0F);
+					GlStateManager.rotate(25F * (float)mecha.ticksExisted, 1F, 0F, 0F);
 				}
 				toolType.model.renderDrill(mecha, dT);
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 				toolType.model.renderSaw(mecha, dT, (leftHand && mecha.primaryShootHeld) || (!leftHand && mecha.secondaryShootHeld));
 			}
 		}
@@ -423,27 +424,27 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 			GunType gunType = ((ItemGun)item).GetType();
 			ModelGun model = gunType.model;
 			
-			GL11.glRotatef(-90F, 0F, 0F, 1F);
+			GlStateManager.rotate(-90F, 0F, 0F, 1F);
 			texturemanager.bindTexture(FlansModResourceHandler.getTexture(gunType));
 			ClientProxy.gunRenderer.renderGun(stack, gunType, 1F / 16F, model, leftHand ? mecha.leftAnimations : mecha.rightAnimations, 0F);
 		}
 		else
 		{
-			GL11.glRotatef(-135F, 0F, 0F, 1F);
-			GL11.glTranslatef(0F, -0.4F, 0F);
+			GlStateManager.rotate(-135F, 0F, 0F, 1F);
+			GlStateManager.translate(0F, -0.4F, 0F);
 			
 			IBakedModel ibakedmodel = renderItem.getItemModelMesher().getItemModel(stack);
 			renderItem.renderItem(stack, ibakedmodel);
 			
 			GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override
 	public void renderItem(CustomItemRenderType type, EnumHand hand, ItemStack item, Object... data)
 	{
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		if(item != null && item.getItem() instanceof ItemMecha)
 		{
 			MechaType mechaType = ((ItemMecha)item.getItem()).type;
@@ -455,42 +456,42 @@ public class RenderMecha extends Render<EntityMecha> implements CustomItemRender
 					case INVENTORY:
 					{
 						scale = 1.0F;
-						GL11.glTranslatef(0F, -0.35F, 0F);
+						GlStateManager.translate(0F, -0.35F, 0F);
 						break;
 					}
 					case ENTITY:
 					{
 						scale = 1.5F;
-						//GL11.glRotatef(((EntityItem)data[1]).ticksExisted, 0F, 1F, 0F);
+						//GlStateManager.rotate(((EntityItem)data[1]).ticksExisted, 0F, 1F, 0F);
 						break;
 					}
 					case EQUIPPED:
 					{
-						GL11.glRotatef(0F, 0F, 0F, 1F);
-						GL11.glRotatef(270F, 1F, 0F, 0F);
-						GL11.glRotatef(270F, 0F, 1F, 0F);
-						GL11.glTranslatef(0F, 0.25F, 0F);
+						GlStateManager.rotate(0F, 0F, 0F, 1F);
+						GlStateManager.rotate(270F, 1F, 0F, 0F);
+						GlStateManager.rotate(270F, 0F, 1F, 0F);
+						GlStateManager.translate(0F, 0.25F, 0F);
 						scale = 0.5F;
 						break;
 					}
 					case EQUIPPED_FIRST_PERSON:
 					{
-						//GL11.glRotatef(25F, 0F, 0F, 1F);
-						GL11.glRotatef(45F, 0F, 1F, 0F);
-						GL11.glTranslatef(-0.5F, 0.5F, -0.5F);
+						//GlStateManager.rotate(25F, 0F, 0F, 1F);
+						GlStateManager.rotate(45F, 0F, 1F, 0F);
+						GlStateManager.translate(-0.5F, 0.5F, -0.5F);
 						scale = 1F;
 						break;
 					}
 					default: break;
 				}
 				
-				GL11.glScalef(scale / mechaType.cameraDistance, scale / mechaType.cameraDistance, scale / mechaType.cameraDistance);
+				GlStateManager.scale(scale / mechaType.cameraDistance, scale / mechaType.cameraDistance, scale / mechaType.cameraDistance);
 				Minecraft.getMinecraft().renderEngine.bindTexture(FlansModResourceHandler.getTexture(mechaType));
 				ModelDriveable model = mechaType.model;
 				model.render(mechaType);
 			}
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	public static class Factory implements IRenderFactory<EntityMecha>

--- a/src/main/java/com/flansmod/client/model/RenderNull.java
+++ b/src/main/java/com/flansmod/client/model/RenderNull.java
@@ -3,6 +3,7 @@ package com.flansmod.client.model;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
@@ -32,24 +33,24 @@ public class RenderNull<E extends Entity> extends Render<E>
 	{
 		if(FlansMod.DEBUG)
 		{
-			GL11.glPushMatrix();
-			GL11.glTranslatef((float)d, (float)d1, (float)d2);
-			GL11.glRotatef(-entity.rotationYaw, 0F, 1F, 0F);
-			GL11.glDisable(GL11.GL_TEXTURE_2D);
-			//GL11.glEnable(GL11.GL_BLEND);
+			GlStateManager.pushMatrix();
+			GlStateManager.translate((float)d, (float)d1, (float)d2);
+			GlStateManager.rotate(-entity.rotationYaw, 0F, 1F, 0F);
+			GlStateManager.disableTexture2D();
+			//GlStateManager.enableBlend();
 			//GL11.glDisable(GL11.GL_DEPTH_TEST);
 			if(entity instanceof EntitySeat)
 			{
-				GL11.glColor4f(1F, 1F, 1F, 1F);
+				GlStateManager.color(1F, 1F, 1F, 1F);
 			}
-			else GL11.glColor4f(0F, 0F, 1F, 0.3F);
-			GL11.glScalef(-1F, 1F, -1F);
+			else GlStateManager.color(0F, 0F, 1F, 0.3F);
+			GlStateManager.scale(-1F, 1F, -1F);
 			renderOffsetAABB(new AxisAlignedBB(-1F, -1F, -1F, 1F, 1F, 1F), 0, 0, 0);
-			GL11.glEnable(GL11.GL_TEXTURE_2D);
+			GlStateManager.enableTexture2D();
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
-			GL11.glDisable(GL11.GL_BLEND);
-			GL11.glColor4f(1F, 1F, 1F, 1F);
-			GL11.glPopMatrix();
+			GlStateManager.disableBlend();
+			GlStateManager.color(1F, 1F, 1F, 1F);
+			GlStateManager.popMatrix();
 		}
 	}
 	

--- a/src/main/java/com/flansmod/client/model/RenderParachute.java
+++ b/src/main/java/com/flansmod/client/model/RenderParachute.java
@@ -1,8 +1,7 @@
 package com.flansmod.client.model;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
@@ -23,13 +22,13 @@ public class RenderParachute extends Render<EntityParachute>
 	public void doRender(EntityParachute entity, double d0, double d1, double d2, float f, float f1)
 	{
 		bindEntityTexture(entity);
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d0, (float)d1, (float)d2);
-		GL11.glRotatef(-f, 0.0F, 1.0F, 0.0F);
-		GL11.glRotatef(-entity.prevRotationPitch - (entity.rotationPitch - entity.prevRotationPitch) * f1, 1.0F, 0.0F, 0.0F);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate((float)d0, (float)d1, (float)d2);
+		GlStateManager.rotate(-f, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(-entity.prevRotationPitch - (entity.rotationPitch - entity.prevRotationPitch) * f1, 1.0F, 0.0F, 0.0F);
 		ModelBase model = entity.type.model;
 		model.render(entity, 0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/client/model/RenderPlane.java
+++ b/src/main/java/com/flansmod/client/model/RenderPlane.java
@@ -47,8 +47,10 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 	{
 		bindEntityTexture(entityPlane);
 		PlaneType type = entityPlane.getPlaneType();
-		GL11.glPushMatrix();
-		GL11.glTranslatef((float)d, (float)d1, (float)d2);
+//		GlStateManager.pushMatrix();
+//		GlStateManager.translate((float)d, (float)d1, (float)d2);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(d, d1, d2);
 		float dYaw = (entityPlane.axes.getYaw() - entityPlane.prevRotationYaw);
 		while(dYaw > 180F)
 		{
@@ -76,12 +78,16 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 		{
 			dRoll += 360F;
 		}
-		GL11.glRotatef(180F - entityPlane.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
-		GL11.glRotatef(entityPlane.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
-		GL11.glRotatef(entityPlane.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
+//		GlStateManager.rotate(180F - entityPlane.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
+//		GlStateManager.rotate(entityPlane.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
+//		GlStateManager.rotate(entityPlane.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
+		GlStateManager.rotate(180F - entityPlane.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
+		GlStateManager.rotate(entityPlane.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
+		GlStateManager.rotate(entityPlane.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
 		
 		float modelScale = type.modelScale;
-		GL11.glScalef(modelScale, modelScale, modelScale);
+//		GlStateManager.scale(modelScale, modelScale, modelScale);
+		GlStateManager.scale(modelScale, modelScale, modelScale);
 		ModelPlane model = (ModelPlane)type.model;
 		if(model != null)
 		{
@@ -89,50 +95,58 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 			// Render helicopter main rotors
 			for(int i = 0; i < model.heliMainRotorModels.length; i++)
 			{
-				GL11.glPushMatrix();
-				GL11.glTranslatef(model.heliMainRotorOrigins[i].x, model.heliMainRotorOrigins[i].y,
-						model.heliMainRotorOrigins[i].z);
-				GL11.glRotatef(
-						(entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * model.heliRotorSpeeds[i] * 1440F /
-								3.14159265F, 0.0F, 1.0F, 0.0F);
-				GL11.glTranslatef(-model.heliMainRotorOrigins[i].x, -model.heliMainRotorOrigins[i].y,
-						-model.heliMainRotorOrigins[i].z);
-				model.renderRotor(entityPlane, 0.0625F, i);
-				GL11.glPopMatrix();
+//				GlStateManager.pushMatrix();
+				//GlStateManager.translate(model.heliMainRotorOrigins[i].x, model.heliMainRotorOrigins[i].y, model.heliMainRotorOrigins[i].z);
+				//GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * model.heliRotorSpeeds[i] * 1440F /3.14159265F, 0.0F, 1.0F, 0.0F);
+				//GlStateManager.translate(-model.heliMainRotorOrigins[i].x, -model.heliMainRotorOrigins[i].y,-model.heliMainRotorOrigins[i].z);
+				//model.renderRotor(entityPlane, 0.0625F, i);
+				//GlStateManager.popMatrix();
+				
+				
+				GlStateManager.pushMatrix();
+				GlStateManager.translate(model.heliMainRotorOrigins[i].x, model.heliMainRotorOrigins[i].y, model.heliMainRotorOrigins[i].z);
+				GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * model.heliRotorSpeeds[i] * 1440F /3.14159265F, 0.0F, 1.0F, 0.0F);
+				GlStateManager.translate(-model.heliMainRotorOrigins[i].x, -model.heliMainRotorOrigins[i].y,-model.heliMainRotorOrigins[i].z);
+				model.renderRotor(entityPlane, 0.0625F, i); //work
+				GlStateManager.popMatrix();
 			}
 			// Render helicopter tail rotors
 			for(int i = 0; i < model.heliTailRotorModels.length; i++)
 			{
-				GL11.glPushMatrix();
-				GL11.glTranslatef(model.heliTailRotorOrigins[i].x, model.heliTailRotorOrigins[i].y,
-						model.heliTailRotorOrigins[i].z);
-				GL11.glRotatef((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * 1440F / 3.14159265F, 0.0F,
-						0.0F, 1.0F);
-				GL11.glTranslatef(-model.heliTailRotorOrigins[i].x, -model.heliTailRotorOrigins[i].y,
-						-model.heliTailRotorOrigins[i].z);
-				model.renderTailRotor(entityPlane, 0.0625F, i);
-				GL11.glPopMatrix();
+				//GlStateManager.pushMatrix();
+				//GlStateManager.translate(model.heliTailRotorOrigins[i].x, model.heliTailRotorOrigins[i].y,model.heliTailRotorOrigins[i].z);
+				//GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * 1440F / 3.14159265F, 0.0F, 0.0F, 1.0F);
+				//GlStateManager.translate(-model.heliTailRotorOrigins[i].x, -model.heliTailRotorOrigins[i].y, -model.heliTailRotorOrigins[i].z);
+				//model.renderTailRotor(entityPlane, 0.0625F, i);
+				//GlStateManager.popMatrix();
+				
+				GlStateManager.pushMatrix();
+				GlStateManager.translate(model.heliTailRotorOrigins[i].x, model.heliTailRotorOrigins[i].y, model.heliTailRotorOrigins[i].z);
+				GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * 1440F / 3.14159265F, 0.0F, 0.0F, 1.0F);
+				GlStateManager.translate(-model.heliTailRotorOrigins[i].x, -model.heliTailRotorOrigins[i].y, -model.heliTailRotorOrigins[i].z);
+				model.renderTailRotor(entityPlane, 0.0625F, i); //work
+				GlStateManager.popMatrix();
 			}
 		}
 		
 		if(FlansMod.DEBUG)
 		{
-			GL11.glDisable(GL11.GL_TEXTURE_2D);
-			GL11.glEnable(GL11.GL_BLEND);
+			GlStateManager.disableTexture2D();
+			GlStateManager.enableBlend();
 			GL11.glDisable(GL11.GL_DEPTH_TEST);
-			GL11.glColor4f(1F, 0F, 0F, 0.3F);
-			GL11.glScalef(-1F, 1F, -1F);
+			GlStateManager.color(1F, 0F, 0F, 0.3F);
+			GlStateManager.scale(-1F, 1F, -1F);
 			for(DriveablePart part : entityPlane.getDriveableData().parts.values())
 			{
 				if(part.box == null)
 					continue;
 				
-				GL11.glColor4f(1F, entityPlane.isPartIntact(part.type) ? 1F : 0F, 0F, 0.3F);
+				GlStateManager.color(1F, entityPlane.isPartIntact(part.type) ? 1F : 0F, 0F, 0.3F);
 				
 				renderOffsetAABB(new AxisAlignedBB(part.box.x, part.box.y, part.box.z, (part.box.x + part.box.w),
 						(part.box.y + part.box.h), (part.box.z + part.box.d)), 0, 0, 0);
 			}
-			GL11.glColor4f(1F, 1F, 0F, 0.3F);
+			GlStateManager.color(1F, 1F, 0F, 0.3F);
 			for(Propeller prop : type.propellers)
 			{
 				renderOffsetAABB(new AxisAlignedBB(prop.x / 16F - 0.25F, prop.y / 16F - 0.25F, prop.z / 16F - 0.25F,
@@ -140,7 +154,7 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 			}
 			
 			// Render shoot points
-			GL11.glColor4f(1F, 0F, 1F, 0.3F);
+			GlStateManager.color(1F, 0F, 1F, 0.3F);
 			for(ShootPoint point : type.shootPointsPrimary)
 			{
 				DriveablePosition driveablePosition = point.rootPos;
@@ -154,7 +168,7 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 					0, 0, 0);
 			}
 			
-			GL11.glColor4f(0F, 1F, 0F, 0.3F);
+			GlStateManager.color(0F, 1F, 0F, 0.3F);
 			for(ShootPoint point : type.shootPointsSecondary)
 			{
 				DriveablePosition driveablePosition = point.rootPos;
@@ -169,12 +183,13 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 			}
 			
 			
-			GL11.glEnable(GL11.GL_TEXTURE_2D);
+			GlStateManager.enableTexture2D();
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
-			GL11.glDisable(GL11.GL_BLEND);
-			GL11.glColor4f(1F, 1F, 1F, 1F);
+			GlStateManager.disableBlend();
+			GlStateManager.color(1F, 1F, 1F, 1F);
 		}
-		GL11.glPopMatrix();
+		//GlStateManager.popMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override
@@ -215,16 +230,21 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 		//frustrum.setPosition(x, y, z);
 		
 		//Push
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		//Setup lighting
-		Minecraft.getMinecraft().entityRenderer.enableLightmap();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glDisable(GL11.GL_BLEND);
+//		Minecraft.getMinecraft().entityRenderer.enableLightmap();
+//		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+//		GL11.glEnable(GL11.GL_LIGHTING);
+//		GlStateManager.disableBlend();
+		GlStateManager.disableBlend();
+//		GlStateManager.disableCull();
+		GlStateManager.enableLighting();
 		
-		RenderHelper.enableStandardItemLighting();
+//		RenderHelper.disableStandardItemLighting();
+//		RenderHelper.enableStandardItemLighting();
+//		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		
-		GL11.glTranslatef(-(float)x, -(float)y, -(float)z);
+		GlStateManager.translate(-x, -y, -z);
 		for(Object entity : world.loadedEntityList)
 		{
 			if(entity instanceof EntityPlane)
@@ -251,17 +271,21 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 		}
 		
 		//Reset Lighting
-		Minecraft.getMinecraft().entityRenderer.disableLightmap();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		GL11.glDisable(GL11.GL_LIGHTING);
+//		Minecraft.getMinecraft().entityRenderer.disableLightmap();
+//		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+//		GL11.glDisable(GL11.GL_LIGHTING);
+//		GlStateManager.disableLighting();
+//		GlStateManager.enableCull();
+		GlStateManager.disableBlend();
 		//Pop
-		GL11.glPopMatrix();
+//		GlStateManager.popMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override
 	public void renderItem(CustomItemRenderType type, EnumHand hand, ItemStack item, Object... data)
 	{
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		if(item != null && item.getItem() instanceof ItemPlane)
 		{
 			PlaneType planeType = ((ItemPlane)item.getItem()).type;
@@ -272,7 +296,7 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 				{
 					case INVENTORY:
 					{
-						GL11.glRotatef(180F, 0F, 1F, 0F);
+						GlStateManager.rotate(180F, 0F, 1F, 0F);
 						scale = 1.0F;
 						break;
 					}
@@ -283,10 +307,10 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 					}
 					case EQUIPPED:
 					{
-						GL11.glRotatef(0F, 0F, 0F, 1F);
-						GL11.glRotatef(270F, 1F, 0F, 0F);
-						GL11.glRotatef(270F, 0F, 1F, 0F);
-						GL11.glTranslatef(0F, 0.25F, 0F);
+						GlStateManager.rotate(0F, 0F, 0F, 1F);
+						GlStateManager.rotate(270F, 1F, 0F, 0F);
+						GlStateManager.rotate(270F, 0F, 1F, 0F);
+						GlStateManager.translate(0F, 0.25F, 0F);
 						scale = 0.5F;
 						break;
 					}
@@ -294,15 +318,15 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 					{
 						if(hand == EnumHand.MAIN_HAND)
 						{
-							GL11.glRotatef(45F, 0F, 1F, 0F);
-							GL11.glTranslatef(-0.5F, 0.5F, -0.5F);
-							GL11.glRotatef(180F, 0F, 1F, 0F);
+							GlStateManager.rotate(45F, 0F, 1F, 0F);
+							GlStateManager.translate(-0.5F, 0.5F, -0.5F);
+							GlStateManager.rotate(180F, 0F, 1F, 0F);
 						}
 						else
 						{
-							GL11.glRotatef(45F, 0F, 1F, 0F);
-							GL11.glTranslatef(-0.5F, 0.5F, -2.3F);
-							GL11.glRotatef(180F, 0F, 1F, 0F);
+							GlStateManager.rotate(45F, 0F, 1F, 0F);
+							GlStateManager.translate(-0.5F, 0.5F, -2.3F);
+							GlStateManager.rotate(180F, 0F, 1F, 0F);
 						}
 						scale = 1F;
 						break;
@@ -311,14 +335,14 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 						break;
 				}
 				
-				GL11.glScalef(scale / planeType.cameraDistance, scale / planeType.cameraDistance,
+				GlStateManager.scale(scale / planeType.cameraDistance, scale / planeType.cameraDistance,
 						scale / planeType.cameraDistance);
 				Minecraft.getMinecraft().renderEngine.bindTexture(FlansModResourceHandler.getTexture(planeType));
 				ModelDriveable model = planeType.model;
 				model.render(planeType);
 			}
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	public static class Factory implements IRenderFactory<EntityPlane>

--- a/src/main/java/com/flansmod/client/model/RenderPlane.java
+++ b/src/main/java/com/flansmod/client/model/RenderPlane.java
@@ -47,8 +47,6 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 	{
 		bindEntityTexture(entityPlane);
 		PlaneType type = entityPlane.getPlaneType();
-//		GlStateManager.pushMatrix();
-//		GlStateManager.translate((float)d, (float)d1, (float)d2);
 		GlStateManager.pushMatrix();
 		GlStateManager.translate(d, d1, d2);
 		float dYaw = (entityPlane.axes.getYaw() - entityPlane.prevRotationYaw);
@@ -78,15 +76,11 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 		{
 			dRoll += 360F;
 		}
-//		GlStateManager.rotate(180F - entityPlane.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
-//		GlStateManager.rotate(entityPlane.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
-//		GlStateManager.rotate(entityPlane.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
 		GlStateManager.rotate(180F - entityPlane.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
 		GlStateManager.rotate(entityPlane.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
 		GlStateManager.rotate(entityPlane.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
 		
 		float modelScale = type.modelScale;
-//		GlStateManager.scale(modelScale, modelScale, modelScale);
 		GlStateManager.scale(modelScale, modelScale, modelScale);
 		ModelPlane model = (ModelPlane)type.model;
 		if(model != null)
@@ -95,14 +89,6 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 			// Render helicopter main rotors
 			for(int i = 0; i < model.heliMainRotorModels.length; i++)
 			{
-//				GlStateManager.pushMatrix();
-				//GlStateManager.translate(model.heliMainRotorOrigins[i].x, model.heliMainRotorOrigins[i].y, model.heliMainRotorOrigins[i].z);
-				//GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * model.heliRotorSpeeds[i] * 1440F /3.14159265F, 0.0F, 1.0F, 0.0F);
-				//GlStateManager.translate(-model.heliMainRotorOrigins[i].x, -model.heliMainRotorOrigins[i].y,-model.heliMainRotorOrigins[i].z);
-				//model.renderRotor(entityPlane, 0.0625F, i);
-				//GlStateManager.popMatrix();
-				
-				
 				GlStateManager.pushMatrix();
 				GlStateManager.translate(model.heliMainRotorOrigins[i].x, model.heliMainRotorOrigins[i].y, model.heliMainRotorOrigins[i].z);
 				GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * model.heliRotorSpeeds[i] * 1440F /3.14159265F, 0.0F, 1.0F, 0.0F);
@@ -113,13 +99,6 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 			// Render helicopter tail rotors
 			for(int i = 0; i < model.heliTailRotorModels.length; i++)
 			{
-				//GlStateManager.pushMatrix();
-				//GlStateManager.translate(model.heliTailRotorOrigins[i].x, model.heliTailRotorOrigins[i].y,model.heliTailRotorOrigins[i].z);
-				//GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * 1440F / 3.14159265F, 0.0F, 0.0F, 1.0F);
-				//GlStateManager.translate(-model.heliTailRotorOrigins[i].x, -model.heliTailRotorOrigins[i].y, -model.heliTailRotorOrigins[i].z);
-				//model.renderTailRotor(entityPlane, 0.0625F, i);
-				//GlStateManager.popMatrix();
-				
 				GlStateManager.pushMatrix();
 				GlStateManager.translate(model.heliTailRotorOrigins[i].x, model.heliTailRotorOrigins[i].y, model.heliTailRotorOrigins[i].z);
 				GlStateManager.rotate((entityPlane.propAngle + f1 * entityPlane.throttle / 7F) * 1440F / 3.14159265F, 0.0F, 0.0F, 1.0F);
@@ -188,7 +167,6 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 			GlStateManager.disableBlend();
 			GlStateManager.color(1F, 1F, 1F, 1F);
 		}
-		//GlStateManager.popMatrix();
 		GlStateManager.popMatrix();
 	}
 	
@@ -232,17 +210,12 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 		//Push
 		GlStateManager.pushMatrix();
 		//Setup lighting
-//		Minecraft.getMinecraft().entityRenderer.enableLightmap();
-//		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-//		GL11.glEnable(GL11.GL_LIGHTING);
-//		GlStateManager.disableBlend();
-		GlStateManager.disableBlend();
-//		GlStateManager.disableCull();
+		Minecraft.getMinecraft().entityRenderer.enableLightmap();
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GlStateManager.enableLighting();
+		GlStateManager.disableBlend();
 		
-//		RenderHelper.disableStandardItemLighting();
-//		RenderHelper.enableStandardItemLighting();
-//		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+		RenderHelper.enableStandardItemLighting();
 		
 		GlStateManager.translate(-x, -y, -z);
 		for(Object entity : world.loadedEntityList)
@@ -271,14 +244,10 @@ public class RenderPlane extends Render<EntityPlane> implements CustomItemRender
 		}
 		
 		//Reset Lighting
-//		Minecraft.getMinecraft().entityRenderer.disableLightmap();
-//		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-//		GL11.glDisable(GL11.GL_LIGHTING);
-//		GlStateManager.disableLighting();
-//		GlStateManager.enableCull();
-		GlStateManager.disableBlend();
+		Minecraft.getMinecraft().entityRenderer.disableLightmap();
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.disableLighting();
 		//Pop
-//		GlStateManager.popMatrix();
 		GlStateManager.popMatrix();
 	}
 	

--- a/src/main/java/com/flansmod/client/model/RenderVehicle.java
+++ b/src/main/java/com/flansmod/client/model/RenderVehicle.java
@@ -45,9 +45,9 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 	{
 		bindEntityTexture(vehicle);
 		VehicleType type = vehicle.getVehicleType();
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		{
-			GL11.glTranslatef((float)d, (float)d1, (float)d2);
+			GlStateManager.translate((float)d, (float)d1, (float)d2);
 			float dYaw = (vehicle.axes.getYaw() - vehicle.prevRotationYaw);
 			while(dYaw > 180F)
 			{
@@ -75,20 +75,20 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 			{
 				dRoll += 360F;
 			}
-			GL11.glRotatef(180F - vehicle.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
-			GL11.glRotatef(vehicle.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
-			GL11.glRotatef(vehicle.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
-			GL11.glRotatef(180F, 0.0F, 1.0F, 0.0F);
+			GlStateManager.rotate(180F - vehicle.prevRotationYaw - dYaw * f1, 0.0F, 1.0F, 0.0F);
+			GlStateManager.rotate(vehicle.prevRotationPitch + dPitch * f1, 0.0F, 0.0F, 1.0F);
+			GlStateManager.rotate(vehicle.prevRotationRoll + dRoll * f1, 1.0F, 0.0F, 0.0F);
+			GlStateManager.rotate(180F, 0.0F, 1.0F, 0.0F);
 			
 			float modelScale = type.modelScale;
-			GL11.glPushMatrix();
+			GlStateManager.pushMatrix();
 			{
-				GL11.glScalef(modelScale, modelScale, modelScale);
+				GlStateManager.scale(modelScale, modelScale, modelScale);
 				ModelVehicle modVehicle = (ModelVehicle)type.model;
 				if(modVehicle != null)
 					modVehicle.render(vehicle, f1);
 				
-				GL11.glPushMatrix();
+				GlStateManager.pushMatrix();
 				if(type.turretOrigin != null && vehicle.isPartIntact(EnumDriveablePart.turret) &&
 						vehicle.getSeat(0) != null)
 				{
@@ -103,21 +103,21 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 					}
 					float yaw = vehicle.getSeat(0).prevLooking.getYaw() + dYaw * f1;
 					
-					GL11.glTranslatef(type.turretOrigin.x, type.turretOrigin.y, type.turretOrigin.z);
-					GL11.glRotatef(-yaw, 0.0F, 1.0F, 0.0F);
-					GL11.glTranslatef(-type.turretOrigin.x, -type.turretOrigin.y, -type.turretOrigin.z);
+					GlStateManager.translate(type.turretOrigin.x, type.turretOrigin.y, type.turretOrigin.z);
+					GlStateManager.rotate(-yaw, 0.0F, 1.0F, 0.0F);
+					GlStateManager.translate(-type.turretOrigin.x, -type.turretOrigin.y, -type.turretOrigin.z);
 					
 					if(modVehicle != null)
 						modVehicle.renderTurret(0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F, vehicle, f1);
 					
 					if(FlansMod.DEBUG)
 					{
-						GL11.glTranslatef(type.turretOrigin.x, type.turretOrigin.y, type.turretOrigin.z);
-						GL11.glRotatef(-vehicle.getSeat(0).looking.getPitch(), 0.0F, 0.0F, 1.0F);
-						GL11.glTranslatef(-type.turretOrigin.x, -type.turretOrigin.y, -type.turretOrigin.z);
+						GlStateManager.translate(type.turretOrigin.x, type.turretOrigin.y, type.turretOrigin.z);
+						GlStateManager.rotate(-vehicle.getSeat(0).looking.getPitch(), 0.0F, 0.0F, 1.0F);
+						GlStateManager.translate(-type.turretOrigin.x, -type.turretOrigin.y, -type.turretOrigin.z);
 						
 						//Render shoot points
-						GL11.glColor4f(0F, 0F, 1F, 0.3F);
+						GlStateManager.color(0F, 0F, 1F, 0.3F);
 						for(ShootPoint point : type.shootPointsPrimary)
 						{
 							DriveablePosition driveablePosition = point.rootPos;
@@ -134,7 +134,7 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 							}
 						}
 						
-						GL11.glColor4f(0F, 1F, 0F, 0.3F);
+						GlStateManager.color(0F, 1F, 0F, 0.3F);
 						for(ShootPoint point : type.shootPointsSecondary)
 						{
 							DriveablePosition driveablePosition = point.rootPos;
@@ -150,30 +150,30 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 						}
 					}
 				}
-				GL11.glPopMatrix();
+				GlStateManager.popMatrix();
 				if(modVehicle != null)
 				{
-					GL11.glPushMatrix();
+					GlStateManager.pushMatrix();
 					
-					GL11.glTranslatef(modVehicle.drillHeadOrigin.x, modVehicle.drillHeadOrigin.y,
+					GlStateManager.translate(modVehicle.drillHeadOrigin.x, modVehicle.drillHeadOrigin.y,
 							modVehicle.drillHeadOrigin.z);
-					GL11.glRotatef(vehicle.harvesterAngle * 50F, 1.0F, 0.0F, 0.0F);
-					GL11.glTranslatef(-modVehicle.drillHeadOrigin.x, -modVehicle.drillHeadOrigin.y,
+					GlStateManager.rotate(vehicle.harvesterAngle * 50F, 1.0F, 0.0F, 0.0F);
+					GlStateManager.translate(-modVehicle.drillHeadOrigin.x, -modVehicle.drillHeadOrigin.y,
 							-modVehicle.drillHeadOrigin.z);
 					modVehicle.renderDrillBit(vehicle, f1);
 					
-					GL11.glPopMatrix();
+					GlStateManager.popMatrix();
 				}
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 			
 			if(FlansMod.DEBUG)
 			{
-				GL11.glDisable(GL11.GL_TEXTURE_2D);
-				GL11.glEnable(GL11.GL_BLEND);
+				GlStateManager.disableTexture2D();
+				GlStateManager.enableBlend();
 				GL11.glDisable(GL11.GL_DEPTH_TEST);
-				GL11.glColor4f(1F, 0F, 0F, 0.3F);
-				GL11.glScalef(1F, 1F, 1F);
+				GlStateManager.color(1F, 0F, 0F, 0.3F);
+				GlStateManager.scale(1F, 1F, 1F);
 				for(DriveablePart part : vehicle.getDriveableData().parts.values())
 				{
 					if(part.box == null)
@@ -184,7 +184,7 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 				}
 				
 				// Render shoot points
-				GL11.glColor4f(0F, 0F, 1F, 0.3F);
+				GlStateManager.color(0F, 0F, 1F, 0.3F);
 				for(ShootPoint point : type.shootPointsPrimary)
 				{
 					DriveablePosition driveablePosition = point.rootPos;
@@ -201,7 +201,7 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 					}
 				}
 				
-				GL11.glColor4f(0F, 1F, 0F, 0.3F);
+				GlStateManager.color(0F, 1F, 0F, 0.3F);
 				for(ShootPoint point : type.shootPointsSecondary)
 				{
 					DriveablePosition driveablePosition = point.rootPos;
@@ -216,13 +216,13 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 							0, 0, 0);
 				}
 				
-				GL11.glEnable(GL11.GL_TEXTURE_2D);
+				GlStateManager.enableTexture2D();
 				GL11.glEnable(GL11.GL_DEPTH_TEST);
-				GL11.glDisable(GL11.GL_BLEND);
-				GL11.glColor4f(1F, 1F, 1F, 1F);
+				GlStateManager.disableBlend();
+				GlStateManager.color(1F, 1F, 1F, 1F);
 			}
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override
@@ -243,7 +243,7 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 	@Override
 	public void renderItem(CustomItemRenderType type, EnumHand hand, ItemStack item, Object... data)
 	{
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		if(item != null && item.getItem() instanceof ItemVehicle)
 		{
 			VehicleType vehicleType = ((ItemVehicle)item.getItem()).type;
@@ -260,15 +260,15 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 					case INVENTORY:
 					{
 						scale = 0.70F;
-						GL11.glTranslatef(0F, -0.05F, 0F);
+						GlStateManager.translate(0F, -0.05F, 0F);
 						break;
 					}
 					case EQUIPPED:
 					{
-						GL11.glRotatef(0F, 0F, 0F, 1F);
-						GL11.glRotatef(270F, 1F, 0F, 0F);
-						GL11.glRotatef(270F, 0F, 1F, 0F);
-						GL11.glTranslatef(0F, 0.25F, 0F);
+						GlStateManager.rotate(0F, 0F, 0F, 1F);
+						GlStateManager.rotate(270F, 1F, 0F, 0F);
+						GlStateManager.rotate(270F, 0F, 1F, 0F);
+						GlStateManager.translate(0F, 0.25F, 0F);
 						scale = 0.5F;
 						break;
 					}
@@ -276,13 +276,13 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 					{
 						if(hand == EnumHand.MAIN_HAND)
 						{
-							GL11.glRotatef(45F, 0F, 1F, 0F);
-							GL11.glTranslatef(-0.5F, 0.5F, -0.5F);
+							GlStateManager.rotate(45F, 0F, 1F, 0F);
+							GlStateManager.translate(-0.5F, 0.5F, -0.5F);
 						}
 						else
 						{
-							GL11.glRotatef(45F, 0F, 1F, 0F);
-							GL11.glTranslatef(-0.5F, 0.5F, -2.3F);
+							GlStateManager.rotate(45F, 0F, 1F, 0F);
+							GlStateManager.translate(-0.5F, 0.5F, -2.3F);
 						}
 						
 						break;
@@ -291,14 +291,14 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 						break;
 				}
 				
-				GL11.glScalef(scale / vehicleType.cameraDistance, scale / vehicleType.cameraDistance,
+				GlStateManager.scale(scale / vehicleType.cameraDistance, scale / vehicleType.cameraDistance,
 						scale / vehicleType.cameraDistance);
 				Minecraft.getMinecraft().renderEngine.bindTexture(FlansModResourceHandler.getTexture(vehicleType));
 				ModelDriveable model = vehicleType.model;
 				model.render(vehicleType);
 			}
 		}
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@SubscribeEvent(priority = EventPriority.LOWEST)
@@ -319,16 +319,16 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 		//frustrum.setPosition(x, y, z);
 		
 		//Push
-		GL11.glPushMatrix();
+		GlStateManager.pushMatrix();
 		//Setup lighting
 		Minecraft.getMinecraft().entityRenderer.enableLightmap();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glDisable(GL11.GL_BLEND);
+		GlStateManager.disableBlend();
 		
 		RenderHelper.enableStandardItemLighting();
 		
-		GL11.glTranslatef(-(float)x, -(float)y, -(float)z);
+		GlStateManager.translate(-(float)x, -(float)y, -(float)z);
 		for(Object entity : world.loadedEntityList)
 		{
 			if(entity instanceof EntityVehicle)
@@ -356,10 +356,10 @@ public class RenderVehicle extends Render<EntityVehicle> implements CustomItemRe
 		
 		//Reset Lighting
 		Minecraft.getMinecraft().entityRenderer.disableLightmap();
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		GL11.glDisable(GL11.GL_LIGHTING);
 		//Pop
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	public static class Factory implements IRenderFactory<EntityVehicle>

--- a/src/main/java/com/flansmod/client/model/mw/ModelMIM23Rocket.java
+++ b/src/main/java/com/flansmod/client/model/mw/ModelMIM23Rocket.java
@@ -38,7 +38,7 @@ public class ModelMIM23Rocket extends ModelBullet
 	@Override
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
-		//GL11.glScalef(0.5F, 0.5F, 0.5F);
+		//GlStateManager.scale(0.5F, 0.5F, 0.5F);
 		for(ModelRendererTurbo mrt : bulletModel)
 			mrt.render(f5);
 	}

--- a/src/main/java/com/flansmod/client/model/mw/ModelMinigun.java
+++ b/src/main/java/com/flansmod/client/model/mw/ModelMinigun.java
@@ -1,12 +1,12 @@
 package com.flansmod.client.model.mw;
 
-import org.lwjgl.opengl.GL11;
-
 import com.flansmod.client.model.EnumAnimationType;
 import com.flansmod.client.model.GunAnimations;
 import com.flansmod.client.model.ModelGun;
 import com.flansmod.client.tmt.ModelRendererTurbo;
 import com.flansmod.common.vector.Vector3f;
+
+import net.minecraft.client.renderer.GlStateManager;
 
 public class ModelMinigun extends ModelGun
 {
@@ -259,11 +259,11 @@ public class ModelMinigun extends ModelGun
 	@Override
 	public void renderCustom(float f, GunAnimations anims)
 	{
-		GL11.glPushMatrix();
-		GL11.glTranslatef(spinnerOrigin.x, spinnerOrigin.y, spinnerOrigin.z);
-		GL11.glRotatef(anims.minigunBarrelRotation, 0F, 0F, 1F);
-		GL11.glTranslatef(-spinnerOrigin.x, -spinnerOrigin.y, -spinnerOrigin.z);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(spinnerOrigin.x, spinnerOrigin.y, spinnerOrigin.z);
+		GlStateManager.rotate(anims.minigunBarrelRotation, 0F, 0F, 1F);
+		GlStateManager.translate(-spinnerOrigin.x, -spinnerOrigin.y, -spinnerOrigin.z);
 		render(spinnerModel, f);
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 }

--- a/src/main/java/com/flansmod/client/model/mw/ModelRPGRocket.java
+++ b/src/main/java/com/flansmod/client/model/mw/ModelRPGRocket.java
@@ -1,8 +1,7 @@
 package com.flansmod.client.model.mw;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 import com.flansmod.client.tmt.ModelRendererTurbo;
@@ -31,7 +30,7 @@ public class ModelRPGRocket extends ModelBase
 	@Override
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
-		GL11.glScalef(0.5F, 0.5F, 0.5F);
+		GlStateManager.scale(0.5F, 0.5F, 0.5F);
 		for(ModelRendererTurbo mrt : bulletModel)
 			mrt.render(f5);
 	}

--- a/src/main/java/com/flansmod/client/model/mw/ModelStingerMissile.java
+++ b/src/main/java/com/flansmod/client/model/mw/ModelStingerMissile.java
@@ -30,7 +30,7 @@ public class ModelStingerMissile extends ModelBullet
 	@Override
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
-		//GL11.glScalef(0.5F, 0.5F, 0.5F);
+		//GlStateManager.scale(0.5F, 0.5F, 0.5F);
 		for(ModelRendererTurbo mrt : bulletModel)
 			mrt.render(f5);
 	}

--- a/src/main/java/com/flansmod/client/model/ww2/ModelFragGrenade.java
+++ b/src/main/java/com/flansmod/client/model/ww2/ModelFragGrenade.java
@@ -9,9 +9,8 @@
 
 package com.flansmod.client.model.ww2;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 import com.flansmod.client.tmt.ModelRendererTurbo;
@@ -598,7 +597,7 @@ public class ModelFragGrenade extends ModelBase
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
 		
-		GL11.glScalef(0.2F, 0.2F, 0.2F);
+		GlStateManager.scale(0.2F, 0.2F, 0.2F);
 		
 		for(int i = 0; i < 96; i++)
 		{

--- a/src/main/java/com/flansmod/client/model/ww2/ModelM8Smoke.java
+++ b/src/main/java/com/flansmod/client/model/ww2/ModelM8Smoke.java
@@ -9,9 +9,8 @@
 
 package com.flansmod.client.model.ww2;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 import com.flansmod.client.tmt.ModelRendererTurbo;
@@ -140,7 +139,7 @@ public class ModelM8Smoke extends ModelBase
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
 
-		GL11.glScalef(0.2F, 0.2F, 0.2F);
+		GlStateManager.scale(0.2F, 0.2F, 0.2F);
 
 		for(int i = 0; i < 18; i++)
 		{

--- a/src/main/java/com/flansmod/client/model/ww2/ModelStickGrenade.java
+++ b/src/main/java/com/flansmod/client/model/ww2/ModelStickGrenade.java
@@ -9,9 +9,8 @@
 
 package com.flansmod.client.model.ww2;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 import com.flansmod.client.tmt.ModelRendererTurbo;
@@ -132,7 +131,7 @@ public class ModelStickGrenade extends ModelBase
 	public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
 	{
 		
-		GL11.glScalef(0.2F, 0.2F, 0.2F);
+		GlStateManager.scale(0.2F, 0.2F, 0.2F);
 		
 		for(int i = 0; i < 20; i++)
 		{

--- a/src/main/java/com/flansmod/client/model/yeolde/ModelArrow.java
+++ b/src/main/java/com/flansmod/client/model/yeolde/ModelArrow.java
@@ -5,6 +5,7 @@ import org.lwjgl.opengl.GL12;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 
 import com.flansmod.client.FlansModClient;
@@ -35,10 +36,10 @@ public class ModelArrow extends ModelBase
 		float var19 = (10 + var11 * 10) / 32.0F;
 		float var20 = 0.05625F;
 		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
-		GL11.glRotatef(90F, 0.0F, 0.0F, 1.0F);
-		GL11.glRotatef(45.0F, 1.0F, 0.0F, 0.0F);
-		GL11.glScalef(var20, var20, var20);
-		GL11.glTranslatef(-4.0F, 0.0F, 0.0F);
+		GlStateManager.rotate(90F, 0.0F, 0.0F, 1.0F);
+		GlStateManager.rotate(45.0F, 1.0F, 0.0F, 0.0F);
+		GlStateManager.scale(var20, var20, var20);
+		GlStateManager.translate(-4.0F, 0.0F, 0.0F);
 		GL11.glNormal3f(var20, 0.0F, 0.0F);
 		worldrenderer.startDrawingQuads();
 		worldrenderer.addVertexWithUV(-7.0D, -2.0D, -2.0D, var16, var18);
@@ -56,8 +57,8 @@ public class ModelArrow extends ModelBase
 
 		for(int var23 = 0; var23 < 4; ++var23)
 		{
-			GL11.glRotatef(90.0F, 1.0F, 0.0F, 0.0F);
-			GL11.glNormal3f(0.0F, 0.0F, var20);
+			GlStateManager.rotate(90.0F, 1.0F, 0.0F, 0.0F);
+			GlStateManager.glNormal3f(0.0F, 0.0F, var20);
 			worldrenderer.startDrawingQuads();
 			worldrenderer.addVertexWithUV(-8.0D, -2.0D, 0.0D, var12, var14);
 			worldrenderer.addVertexWithUV(8.0D, -2.0D, 0.0D, var13, var14);

--- a/src/main/java/com/flansmod/client/tmt/ModelRendererTurbo.java
+++ b/src/main/java/com/flansmod/client/tmt/ModelRendererTurbo.java
@@ -15,6 +15,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.model.TexturedQuad;
 import net.minecraft.client.renderer.GLAllocation;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -2133,23 +2134,23 @@ public class ModelRendererTurbo extends ModelRenderer
 		}
 		if(rotateAngleX != 0.0F || rotateAngleY != 0.0F || rotateAngleZ != 0.0F)
 		{
-			GL11.glPushMatrix();
-			GL11.glTranslatef(rotationPointX * worldScale, rotationPointY * worldScale, rotationPointZ * worldScale);
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(rotationPointX * worldScale, rotationPointY * worldScale, rotationPointZ * worldScale);
 			if(!oldRotateOrder && rotateAngleY != 0.0F)
 			{
-				GL11.glRotatef(rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
+				GlStateManager.rotate(rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
 			}
 			if(rotateAngleZ != 0.0F)
 			{
-				GL11.glRotatef((oldRotateOrder ? -1 : 1) * rotateAngleZ * 57.29578F, 0.0F, 0.0F, 1.0F);
+				GlStateManager.rotate((oldRotateOrder ? -1 : 1) * rotateAngleZ * 57.29578F, 0.0F, 0.0F, 1.0F);
 			}
 			if(oldRotateOrder && rotateAngleY != 0.0F)
 			{
-				GL11.glRotatef(-rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
+				GlStateManager.rotate(-rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
 			}
 			if(rotateAngleX != 0.0F)
 			{
-				GL11.glRotatef(rotateAngleX * 57.29578F, 1.0F, 0.0F, 0.0F);
+				GlStateManager.rotate(rotateAngleX * 57.29578F, 1.0F, 0.0F, 0.0F);
 			}
 			
 			callDisplayList();
@@ -2161,11 +2162,11 @@ public class ModelRendererTurbo extends ModelRenderer
 				}
 				
 			}
-			GL11.glPopMatrix();
+			GlStateManager.popMatrix();
 		}
 		else if(rotationPointX != 0.0F || rotationPointY != 0.0F || rotationPointZ != 0.0F)
 		{
-			GL11.glTranslatef(rotationPointX * worldScale, rotationPointY * worldScale, rotationPointZ * worldScale);
+			GlStateManager.translate(rotationPointX * worldScale, rotationPointY * worldScale, rotationPointZ * worldScale);
 			callDisplayList();
 			if(childModels != null)
 			{
@@ -2175,7 +2176,7 @@ public class ModelRendererTurbo extends ModelRenderer
 				}
 				
 			}
-			GL11.glTranslatef(-rotationPointX * worldScale, -rotationPointY * worldScale, -rotationPointZ * worldScale);
+			GlStateManager.translate(-rotationPointX * worldScale, -rotationPointY * worldScale, -rotationPointZ * worldScale);
 		}
 		else
 		{
@@ -2206,22 +2207,22 @@ public class ModelRendererTurbo extends ModelRenderer
 		{
 			compileDisplayList(f);
 		}
-		GL11.glPushMatrix();
-		GL11.glTranslatef(rotationPointX * f, rotationPointY * f, rotationPointZ * f);
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(rotationPointX * f, rotationPointY * f, rotationPointZ * f);
 		if(rotateAngleY != 0.0F)
 		{
-			GL11.glRotatef(rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
+			GlStateManager.rotate(rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
 		}
 		if(rotateAngleX != 0.0F)
 		{
-			GL11.glRotatef(rotateAngleX * 57.29578F, 1.0F, 0.0F, 0.0F);
+			GlStateManager.rotate(rotateAngleX * 57.29578F, 1.0F, 0.0F, 0.0F);
 		}
 		if(rotateAngleZ != 0.0F)
 		{
-			GL11.glRotatef(rotateAngleZ * 57.29578F, 0.0F, 0.0F, 1.0F);
+			GlStateManager.rotate(rotateAngleZ * 57.29578F, 0.0F, 0.0F, 1.0F);
 		}
 		callDisplayList();
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	
 	@Override
@@ -2241,30 +2242,30 @@ public class ModelRendererTurbo extends ModelRenderer
 		}
 		if(rotateAngleX != 0.0F || rotateAngleY != 0.0F || rotateAngleZ != 0.0F)
 		{
-			GL11.glTranslatef(rotationPointX * f, rotationPointY * f, rotationPointZ * f);
+			GlStateManager.translate(rotationPointX * f, rotationPointY * f, rotationPointZ * f);
 			if(rotateAngleZ != 0.0F)
 			{
-				GL11.glRotatef(rotateAngleZ * 57.29578F, 0.0F, 0.0F, 1.0F);
+				GlStateManager.rotate(rotateAngleZ * 57.29578F, 0.0F, 0.0F, 1.0F);
 			}
 			if(rotateAngleY != 0.0F)
 			{
-				GL11.glRotatef(rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
+				GlStateManager.rotate(rotateAngleY * 57.29578F, 0.0F, 1.0F, 0.0F);
 			}
 			if(rotateAngleX != 0.0F)
 			{
-				GL11.glRotatef(rotateAngleX * 57.29578F, 1.0F, 0.0F, 0.0F);
+				GlStateManager.rotate(rotateAngleX * 57.29578F, 1.0F, 0.0F, 0.0F);
 			}
 		}
 		else if(rotationPointX != 0.0F || rotationPointY != 0.0F || rotationPointZ != 0.0F)
 		{
-			GL11.glTranslatef(rotationPointX * f, rotationPointY * f, rotationPointZ * f);
+			GlStateManager.translate(rotationPointX * f, rotationPointY * f, rotationPointZ * f);
 		}
 	}
 	
 	private void callDisplayList()
 	{
 		if(useLegacyCompiler)
-			GL11.glCallList(displayList);
+			GlStateManager.callList(displayList);
 		else
 		{
 			TextureManager renderEngine = Minecraft.getMinecraft().renderEngine;
@@ -2276,7 +2277,7 @@ public class ModelRendererTurbo extends ModelRenderer
 			{
 				TextureGroup curTexGroup = itr.next();
 				curTexGroup.loadTexture();
-				GL11.glCallList(displayListArray[i]);
+				GlStateManager.callList(displayListArray[i]);
 				if(!defaultTexture.equals(""))
 					renderEngine.bindTexture(new ResourceLocation("", defaultTexture)); //TODO : Check. Not sure about this one
 			}
@@ -2296,7 +2297,7 @@ public class ModelRendererTurbo extends ModelRenderer
 			for(int i = 0; itr.hasNext(); i++)
 			{
 				displayListArray[i] = GLAllocation.generateDisplayLists(1);
-				GL11.glNewList(displayListArray[i], GL11.GL_COMPILE);
+				GlStateManager.glNewList(displayListArray[i], GL11.GL_COMPILE);
 				TmtTessellator tessellator = TmtTessellator.instance;
 				
 				TextureGroup usedGroup = itr.next();
@@ -2305,7 +2306,7 @@ public class ModelRendererTurbo extends ModelRenderer
 					usedGroup.poly.get(j).draw(tessellator, worldScale);
 				}
 				
-				GL11.glEndList();
+				GlStateManager.glEndList();
 			}
 		}
 		
@@ -2315,14 +2316,14 @@ public class ModelRendererTurbo extends ModelRenderer
 	private void compileLegacyDisplayList(float worldScale)
 	{
 		displayList = GLAllocation.generateDisplayLists(1);
-		GL11.glNewList(displayList, GL11.GL_COMPILE);
+		GlStateManager.glNewList(displayList, GL11.GL_COMPILE);
 		TmtTessellator tessellator = TmtTessellator.instance;
 		for(TexturedPolygon face : faces)
 		{
 			face.draw(tessellator, worldScale);
 		}
 		
-		GL11.glEndList();
+		GlStateManager.glEndList();
 	}
 	
 	private PositionTextureVertex vertices[];

--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -540,8 +540,6 @@ public class ItemGun extends Item implements IPaintableItem
 						FlansModClient.playerRecoil += recoil;
 						animations.recoil += recoil;
 						
-						boolean silenced = type.getBarrel(gunstack) != null && type.getBarrel(gunstack).silencer;
-						playShotSound(world, rayTraceOrigin, silenced);
 					} else
 					{
 						Vector3f rayTraceDirection = new Vector3f(player.getLookVec());
@@ -562,7 +560,8 @@ public class ItemGun extends Item implements IPaintableItem
 							handler.shooting(false);
 						}
 						
-						//TODO make server based sound
+						boolean silenced = type.getBarrel(gunstack) != null && type.getBarrel(gunstack).silencer;
+						playShotSound(world, rayTraceOrigin, silenced);
 					}
 				int gunSlot = player.inventory.currentItem;
 				if(type.consumeGunUponUse)

--- a/src/main/java/com/flansmod/common/guns/ShotHandler.java
+++ b/src/main/java/com/flansmod/common/guns/ShotHandler.java
@@ -23,6 +23,7 @@ import com.flansmod.common.network.PacketHitMarker;
 import com.flansmod.common.network.PacketPlaySound;
 import com.flansmod.common.teams.Team;
 import com.flansmod.common.teams.TeamsManager;
+import com.flansmod.common.teams.TeamsRound;
 import com.flansmod.common.types.InfoType;
 import com.flansmod.common.vector.Vector3f;
 
@@ -189,11 +190,13 @@ public class ShotHandler
 			{
 				EntityPlayerMP player = optionalPlayer.get();
 				
-				if(FlansModClient.teamInfo != null)
+				if(TeamsManager.getInstance() != null)
 				{
-					Team shooterTeam = FlansModClient.teamInfo.getTeam(player);
-					Team victimTeam = FlansModClient.teamInfo.getTeam(playerHit.hitbox.player);
-					if(shooterTeam == null || shooterTeam != victimTeam)
+					TeamsRound round = TeamsManager.getInstance().currentRound;
+					
+					Team shooterTeam = round.getTeam(player);
+					Team victimTeam = round.getTeam(playerHit.hitbox.player);
+					
 					{
 						FlansMod.getPacketHandler().sendTo(new PacketHitMarker(), player);
 					}
@@ -264,7 +267,7 @@ public class ShotHandler
 			
 			for (EntityPlayer player : world.playerEntities)
 			{
-				//Checks if the player is in a radius of 300 Blocks (300² = 90000)
+				//Checks if the player is in a radius of 300 Blocks (300 squared = 90000)
 				if (player.getDistanceSq(pos) < 90000)
 				{
 					FlansMod.getPacketHandler().sendTo(new PacketBlockHitEffect(hit, bulletDir, pos, faceing), (EntityPlayerMP) player);

--- a/src/main/java/com/flansmod/common/guns/ShotHandler.java
+++ b/src/main/java/com/flansmod/common/guns/ShotHandler.java
@@ -6,7 +6,6 @@ import static com.flansmod.common.guns.raytracing.FlansModRaytracer.Raytrace;
 import java.util.List;
 import java.util.Optional;
 
-import com.flansmod.client.FlansModClient;
 import com.flansmod.client.debug.EntityDebugDot;
 import com.flansmod.client.debug.EntityDebugVector;
 import com.flansmod.common.FlansMod;
@@ -194,11 +193,15 @@ public class ShotHandler
 				{
 					TeamsRound round = TeamsManager.getInstance().currentRound;
 					
-					Team shooterTeam = round.getTeam(player);
-					Team victimTeam = round.getTeam(playerHit.hitbox.player);
-					
+					if (round != null)
 					{
-						FlansMod.getPacketHandler().sendTo(new PacketHitMarker(), player);
+						Optional<Team> shooterTeam = round.getTeam(player);
+						Optional<Team> victimTeam = round.getTeam(playerHit.hitbox.player);
+					
+						if (!shooterTeam.isPresent() || !victimTeam.isPresent() || !shooterTeam.get().equals(victimTeam.get()))
+						{
+							FlansMod.getPacketHandler().sendTo(new PacketHitMarker(), player);
+						}
 					}
 				}
 				else // No teams mod, just add marker

--- a/src/main/java/com/flansmod/common/teams/TeamsRound.java
+++ b/src/main/java/com/flansmod/common/teams/TeamsRound.java
@@ -1,7 +1,5 @@
 package com.flansmod.common.teams;
 
-import com.flansmod.common.network.PacketTeamInfo.TeamData;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 

--- a/src/main/java/com/flansmod/common/teams/TeamsRound.java
+++ b/src/main/java/com/flansmod/common/teams/TeamsRound.java
@@ -1,5 +1,7 @@
 package com.flansmod.common.teams;
 
+import java.util.Optional;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -114,7 +116,7 @@ public class TeamsRound implements Comparable<TeamsRound>
 		return teams[0];
 	}
 	
-	public Team getTeam(EntityPlayer player)
+	public Optional<Team> getTeam(EntityPlayer player)
 	{
 		String username = player.getName();
 		for(Team team : teams)
@@ -123,11 +125,11 @@ public class TeamsRound implements Comparable<TeamsRound>
 			{
 				if (username.equals(name))
 				{
-					return team;
+					return Optional.of(team);
 				}
 			}
 		}
-		return null;
+		return Optional.empty();
 	}
 	
 	public float getWeight()

--- a/src/main/java/com/flansmod/common/teams/TeamsRound.java
+++ b/src/main/java/com/flansmod/common/teams/TeamsRound.java
@@ -1,5 +1,8 @@
 package com.flansmod.common.teams;
 
+import com.flansmod.common.network.PacketTeamInfo.TeamData;
+
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
 /**
@@ -111,6 +114,22 @@ public class TeamsRound implements Comparable<TeamsRound>
 		if(team == teams[0])
 			return teams[1];
 		return teams[0];
+	}
+	
+	public Team getTeam(EntityPlayer player)
+	{
+		String username = player.getName();
+		for(Team team : teams)
+		{
+			for (String name : team.members)
+			{
+				if (username.equals(name))
+				{
+					return team;
+				}
+			}
+		}
+		return null;
 	}
 	
 	public float getWeight()


### PR DESCRIPTION
This PR removes as much direct access to the OpenGL framework as possible and replaces it with the build-in Minecraft interface GlStateManager.
This fixes the bugs #1046, #1075 and  #932

As i am not an expert on OpenGL any help on the comment i added in com/flansmod/client/ClientRenderHooks.java is appreciated, as i can not confirm, nor deny, any visual difference.

Sidenote: i do not know why the first 6 commits are included in here, they are already merged into the main branch and therefore do not contain any changes.