### PR TITLE
Fixed issue with gradle maven repo http to https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,18 +3,21 @@ buildscript {
         mavenCentral()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
         maven {
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+	maven {
+	    url = "https://repo1.maven.org/maven2/"
+	}
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
     }
+  }
 }
-
 apply plugin: 'forge'
 
 version = "4.10.0"


### PR DESCRIPTION
Maven has dropped support for http on their repositories, as of today/yesterday.
This caused issues for forge gradle 1.7.10, which seems to reference http addresses.

I added `https://repo1.maven.org/maven2/` directly to the repositories list, which seems to force it to use https and therefore work.