### PR TITLE
Fixed null pointer in EntityAAGun

### DIFF
--- a/src/main/java/com/flansmod/common/guns/EntityAAGun.java
+++ b/src/main/java/com/flansmod/common/guns/EntityAAGun.java
@@ -521,7 +521,11 @@ public class EntityAAGun extends Entity implements IEntityAdditionalSpawnData
 			if(ammo[i] != null)
 				nbttagcompound.setTag("Ammo " + i, ammo[i].writeToNBT(new NBTTagCompound()));
 		}
-		nbttagcompound.setString("Placer", placer.getName());
+		if (placer != null) {
+			nbttagcompound.setString("Placer", placer.getName());
+		} else if (placerName != null) {
+			nbttagcompound.setString("Placer", placerName);
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
This prevents null pointer exceptions when the placer is null (e.g. not online, or something else happened)