### PR TITLE
fix vehicle won't fire after world reload

### DIFF
--- a/src/main/java/com/flansmod/client/ClientRenderHooks.java
+++ b/src/main/java/com/flansmod/client/ClientRenderHooks.java
@@ -606,7 +606,7 @@ public class ClientRenderHooks
 			}
 			
 			EntitySeat seat = ((IControllable)mc.player.getRidingEntity()).getSeat(mc.player);
-			if(seat != null && seat.driver && FlansMod.proxy.mouseControlEnabled())
+			if(seat != null && seat.isDriverSeat() && FlansMod.proxy.mouseControlEnabled())
 			{
 				seat.applyOrientationToEntity(mc.player);
 			}

--- a/src/main/java/com/flansmod/common/driveables/EntitySeat.java
+++ b/src/main/java/com/flansmod/common/driveables/EntitySeat.java
@@ -120,7 +120,6 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		driveableID = d.getEntityId();
 		seatInfo = driveable.getDriveableType().seats[id];
 		seatID = id;
-		isDriverSeat();
 		setPosition(d.posX, d.posY, d.posZ);
 		playerPosX = prevPlayerPosX = posX;
 		playerPosY = prevPlayerPosY = posY;

--- a/src/main/java/com/flansmod/common/driveables/EntitySeat.java
+++ b/src/main/java/com/flansmod/common/driveables/EntitySeat.java
@@ -121,7 +121,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		driveableID = d.getEntityId();
 		seatInfo = driveable.getDriveableType().seats[id];
 		seatID = id;
-		driver = id == 0;
+		checkIsDriverSeat();
 		setPosition(d.posX, d.posY, d.posZ);
 		playerPosX = prevPlayerPosX = posX;
 		playerPosY = prevPlayerPosY = posY;
@@ -501,6 +501,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	@Override
 	protected void entityInit()
 	{
+		checkIsDriverSeat();
 	}
 	
 	@Override
@@ -793,17 +794,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	@Override
 	public Entity getControllingPassenger()
 	{
-		List<Entity> _passengers = getPassengers();
-		if(_passengers.isEmpty())
-		{
-			setDriverState(false);
-			return null;
-		}
-		else
-		{
-			setDriverState(true);
-			return _passengers.get(0);
-		}
+		return getPassengers().isEmpty() ? null : getPassengers().get(0);
 	}
 	
 	@Override
@@ -827,10 +818,12 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	{
 		return this;
 	}
-	
-	public void setDriverState(Boolean stat)
+  
+	// Check and update whether currret seat is driver seat
+	public boolean checkIsDriverSeat()
 	{
-		driver = stat;
+		driver = (getExpectedSeatID() == 0);
+		return driver;
 	}
 	
 	@Override
@@ -918,7 +911,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		if(world.getEntityByID(driveableID) instanceof EntityDriveable)
 			driveable = (EntityDriveable)world.getEntityByID(driveableID);
 		seatID = data.readInt();
-		driver = seatID == 0;
+		checkIsDriverSeat();
 		if(seatID >= 0 && driveable != null)
 		{
 			seatInfo = driveable.getDriveableType().seats[seatID];

--- a/src/main/java/com/flansmod/common/driveables/EntitySeat.java
+++ b/src/main/java/com/flansmod/common/driveables/EntitySeat.java
@@ -793,7 +793,17 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	@Override
 	public Entity getControllingPassenger()
 	{
-		return getPassengers().isEmpty() ? null : getPassengers().get(0);
+		List<Entity> _passengers = getPassengers();
+		if(_passengers.isEmpty())
+		{
+			setDriverState(false);
+			return null;
+		}
+		else
+		{
+			setDriverState(true);
+			return _passengers.get(0);
+		}
 	}
 	
 	@Override
@@ -816,6 +826,11 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	public EntitySeat getSeat(EntityLivingBase living)
 	{
 		return this;
+	}
+	
+	public void setDriverState(Boolean stat)
+	{
+		driver = stat;
 	}
 	
 	@Override

--- a/src/main/java/com/flansmod/common/driveables/EntitySeat.java
+++ b/src/main/java/com/flansmod/common/driveables/EntitySeat.java
@@ -54,7 +54,6 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	public float playerRoll, prevPlayerRoll;
 	
 	public Seat seatInfo;
-	public boolean driver;
 	public RotatedAxes playerLooking;
 	public RotatedAxes prevPlayerLooking;
 	/**
@@ -121,7 +120,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		driveableID = d.getEntityId();
 		seatInfo = driveable.getDriveableType().seats[id];
 		seatID = id;
-		checkIsDriverSeat();
+		isDriverSeat();
 		setPosition(d.posX, d.posY, d.posZ);
 		playerPosX = prevPlayerPosX = posX;
 		playerPosY = prevPlayerPosY = posY;
@@ -185,7 +184,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		// If on the client
 		if(world.isRemote)
 		{
-			if(driver && isThePlayer && FlansMod.proxy.mouseControlEnabled() && driveable.hasMouseControlMode())
+			if(isDriverSeat() && isThePlayer && FlansMod.proxy.mouseControlEnabled() && driveable.hasMouseControlMode())
 			{
 				looking = new RotatedAxes();
 				playerLooking = new RotatedAxes();
@@ -501,7 +500,6 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	@Override
 	protected void entityInit()
 	{
-		checkIsDriverSeat();
 	}
 	
 	@Override
@@ -552,12 +550,12 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		prevPlayerLooking = playerLooking.clone();
 		
 		// Driver seat should pass input to driveable
-		if(driver)
+		if(isDriverSeat())
 		{
 			driveable.onMouseMoved(deltaX, deltaY);
 		}
 		// Other seats should look around, but also the driver seat if mouse control mode is disabled
-		if(!driver || !FlansModClient.controlModeMouse || !driveable.hasMouseControlMode())
+		if(!isDriverSeat() || !FlansModClient.controlModeMouse || !driveable.hasMouseControlMode())
 		{
 			float lookSpeed = 4F;
 			
@@ -621,7 +619,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 			FlansMod.getPacketHandler().sendToServer(new PacketDriveableKeyHeld(key, held));
 			
 		}
-		if(driver)
+		if(isDriverSeat())
 		{
 			driveable.updateKeyHeldState(key, held);
 		}
@@ -636,7 +634,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	public boolean pressKey(int key, EntityPlayer player, boolean isOnTick)
 	{
 		// Driver seat should pass input to driveable
-		if(driver && driveable != null)
+		if(isDriverSeat() && driveable != null)
 		{
 			return driveable.pressKey(key, player, isOnTick);
 		}
@@ -820,10 +818,9 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 	}
   
 	// Check and update whether currret seat is driver seat
-	public boolean checkIsDriverSeat()
+	public boolean isDriverSeat()
 	{
-		driver = (getExpectedSeatID() == 0);
-		return driver;
+		return seatID == 0;
 	}
 	
 	@Override
@@ -911,7 +908,6 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		if(world.getEntityByID(driveableID) instanceof EntityDriveable)
 			driveable = (EntityDriveable)world.getEntityByID(driveableID);
 		seatID = data.readInt();
-		checkIsDriverSeat();
 		if(seatID >= 0 && driveable != null)
 		{
 			seatInfo = driveable.getDriveableType().seats[seatID];

--- a/src/main/java/com/flansmod/common/driveables/EntitySeat.java
+++ b/src/main/java/com/flansmod/common/driveables/EntitySeat.java
@@ -816,7 +816,6 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 		return this;
 	}
   
-	// Check and update whether currret seat is driver seat
 	public boolean isDriverSeat()
 	{
 		return seatID == 0;


### PR DESCRIPTION
Vehicle won't able to shoot due to `driver` is set to `false` after a world reload in `EntitySeat.java`, now it has changed properly according to the driver's seat.

But this will result gunner won't be able to fire without the driver, I'll assume that's an intended feature; however if not I can send another PR to fix that.