### PR TITLE
fix #1210, random crash when log-in while mounted on vehicle and turret soundplay

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityDriveable.java
@@ -133,7 +133,14 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
 	public float recoilPos = 0;
 	public float lastRecoilPos = 0;
 	public int recoilTimer = 0;
-	
+
+	/** Can't break the block with hardness greater than this value 
+	 *  when collided */ 
+	public float collisionForce = 30F;
+
+	/** Damage factor of unbreakable block such as bedrock when collided */
+	public float unbreakableBlockDamage = 100F;
+
 	public EntityDriveable(World world)
 	{
 		super(world);
@@ -1330,16 +1337,27 @@ public abstract class EntityDriveable extends Entity implements IControllable, I
 				IBlockState state = world.getBlockState(pos);
 				
 				float blockHardness = state.getBlockHardness(world, pos);
+				float damage = (float)speed;
 				
+				// unbreakable block
+				if(blockHardness < 0F)
+				{
+					damage *= unbreakableBlockDamage * unbreakableBlockDamage;
+				}
+				else
+				{
+					damage *= blockHardness * blockHardness;
+				}
+
 				// Attack the part
-				if(!attackPart(p.part, DamageSource.IN_WALL,
-					blockHardness * blockHardness * (float)speed) && TeamsManager.driveablesBreakBlocks)
+				if(!attackPart(p.part, DamageSource.IN_WALL, damage) 
+					&& TeamsManager.driveablesBreakBlocks)
 				{
 					// And if it didn't die from the attack, break the block
 					// TODO: [1.12] Heck
 					// playAuxSFXAtEntity(null, 2001, pos, Block.getStateId(state));
 					
-					if(!world.isRemote)
+					if(!world.isRemote && blockHardness <= collisionForce)
 					{
 						WorldServer worldServer = (WorldServer)world;
 						destroyBlock(worldServer, pos, getDriver(), true);

--- a/src/main/java/com/flansmod/common/network/PacketSeatUpdates.java
+++ b/src/main/java/com/flansmod/common/network/PacketSeatUpdates.java
@@ -50,6 +50,11 @@ public class PacketSeatUpdates extends PacketBase
 	@Override
 	public void handleServerSide(EntityPlayerMP playerEntity)
 	{
+		if(playerEntity == null)
+		{
+			FlansMod.log.warn("Recevied packet from a null player, skipping!");
+			return ;
+		}
 		EntityDriveable driveable = null;
 		for(Object obj : playerEntity.world.loadedEntityList)
 		{


### PR DESCRIPTION
Fixed #1210 in `EntityDriveable.java` with proper check  and configurable variables to not mess the unbreakable blocks.

A try-catch block in `onMouseMoved` method of `EntitySeat.java` and null player check in `PacketSeatUpdates.java` that will randomly happen and crash client/server when the player previously logged off while on the vehicle (thus player still on it next time logged in), this is probably a hack tho.

Fix turret traversing sound player exit logic that seems written opposite to stop it keeps playing.