### PR TITLE
fix a crash when login on vehicle

### DIFF
--- a/src/main/java/com/flansmod/common/network/PacketSeatUpdates.java
+++ b/src/main/java/com/flansmod/common/network/PacketSeatUpdates.java
@@ -50,6 +50,11 @@ public class PacketSeatUpdates extends PacketBase
 	@Override
 	public void handleServerSide(EntityPlayerMP playerEntity)
 	{
+		if(playerEntity == null)
+		{
+			FlansMod.log.warn("Recevied packet from a null player, skipping!");
+			return ;
+		}
 		EntityDriveable driveable = null;
 		for(Object obj : playerEntity.world.loadedEntityList)
 		{


### PR DESCRIPTION
Add a null player check in `PacketSeatUpdates.java` that will randomly happen and crash client/server when the player login on vehicle