### PR TITLE
fix turret rotate sound repeating

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntitySeat.java
+++ b/src/main/java/com/flansmod/common/driveables/EntitySeat.java
@@ -171,8 +171,7 @@ public class EntitySeat extends Entity implements IControllable, IEntityAddition
 				entityInThisSeat instanceof EntityPlayer && FlansMod.proxy.isThePlayer((EntityPlayer)entityInThisSeat);
 		
 		// Reset traverse sounds if player exits the vehicle
-		
-		if(isThePlayer)
+		if(!isThePlayer)
 		{
 			playYawSound = false;
 			playPitchSound = false;


### PR DESCRIPTION
Fix turret traversing sound player exit logic that seems written opposite to stop it keeps playing while rotating