### PR TITLE
1.12.2 #1270 fix

### DIFF
--- a/run/Flan/Apocalypse Pack/vehicles/Buggy.txt
+++ b/run/Flan/Apocalypse Pack/vehicles/Buggy.txt
@@ -29,7 +29,9 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 20000
+//Increasing fuel tank size in order to beat "Vehicles consume fuel very fast" #1270 issue. It was tested in real game, now jerry cans may fill it fully for 4-5 mins,
+//as in real life, and players have real reason to make fuel stations/storages, dig coal, etc.
 //Inventory Slots
 CargoSlots 32
 ShellSlots 0

--- a/run/Flan/Modern Weapons Pack/planes/A10.txt
+++ b/run/Flan/Modern Weapons Pack/planes/A10.txt
@@ -65,7 +65,8 @@ MissileSlots 4
 AllowAllAmmo False
 AddAmmo mk4Rocket
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 620000
+//6200L IRL
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 105 43 0
 Passengers 0

--- a/run/Flan/Modern Weapons Pack/planes/Apache.txt
+++ b/run/Flan/Modern Weapons Pack/planes/Apache.txt
@@ -61,7 +61,8 @@ MissileSlots 8
 AllowAllAmmo False
 AddAmmo Hellfire
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 143000
+//officially, 1421L+4x871L in aux-tanks. If someone will introduce aux-tanks for helicopter, here is value 87000 for each. 
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 54 32 0
 Passengers 1

--- a/run/Flan/Modern Weapons Pack/planes/B52.txt
+++ b/run/Flan/Modern Weapons Pack/planes/B52.txt
@@ -70,7 +70,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 18173000
+//officially has 181725L fuel capacity and fueled by machines, not jerry cans
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 412 69 -13
 Passengers 5

--- a/run/Flan/Modern Weapons Pack/planes/BlackHawk.txt
+++ b/run/Flan/Modern Weapons Pack/planes/BlackHawk.txt
@@ -57,7 +57,8 @@ MissileSlots 0
 AllowAllAmmo False
 AddAmmo None
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 137000
+//IRL fuel capacity is 1361L+2x700L aux-tanks.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 49 13 14
 Passengers 11

--- a/run/Flan/Modern Weapons Pack/planes/Chinook.txt
+++ b/run/Flan/Modern Weapons Pack/planes/Chinook.txt
@@ -53,12 +53,13 @@ ModePrimary FullAuto
 ModeSecondary FullAuto
 //Add shoot origins. These are the points on your vehicle from which bullets / missiles / shells / bombs appear
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 3
 BombSlots 0
 MissileSlots 0
 AllowAllAmmo False
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 783000
+//7828L (+3x3028L aux-tanks in cargo)
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 154 17 10
 Passengers 25

--- a/run/Flan/Modern Weapons Pack/planes/Cobra.txt
+++ b/run/Flan/Modern Weapons Pack/planes/Cobra.txt
@@ -55,13 +55,14 @@ ModeSecondary FullAuto
 ShootPointPrimary 12 -4 -29 rightWing
 ShootPointPrimary 12 -4 29 leftWing
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 1
 BombSlots 0
 MissileSlots 8
 AllowAllAmmo False
 AddAmmo mk4Rocket
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 116000
+//IRL FC is 1153L and 1165L from 4 aux-tanks, thanks to German Wikipedia
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 32 -4 0
 Passengers 1

--- a/run/Flan/Modern Weapons Pack/planes/F22.txt
+++ b/run/Flan/Modern Weapons Pack/planes/F22.txt
@@ -61,7 +61,8 @@ MissileSlots 4
 AllowAllAmmo False
 AddAmmo mk4Rocket
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 981000
+//8200kg of fuel or 2590USG or 9805L + 2x600USG aux-tanks.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 103 31 0
 Passengers 0

--- a/run/Flan/Modern Weapons Pack/planes/Hind.txt
+++ b/run/Flan/Modern Weapons Pack/planes/Hind.txt
@@ -53,13 +53,14 @@ ModeSecondary FullAuto
 ShootPointPrimary -13 7 -53 rightWing
 ShootPointPrimary -13 7 53 leftWing
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 4
 BombSlots 0
 MissileSlots 8
 AllowAllAmmo False
 AddAmmo mk4Rocket
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 213000
+//2130L in 5 internal tanks total
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 64 18 0
 Passengers 5

--- a/run/Flan/Modern Weapons Pack/planes/LittleBird.txt
+++ b/run/Flan/Modern Weapons Pack/planes/LittleBird.txt
@@ -51,13 +51,14 @@ ModePrimary FullAuto
 ModeSecondary FullAuto
 //Add shoot origins. These are the points on your vehicle from which bullets / missiles / shells / bombs appear
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 2
 BombSlots 0
 MissileSlots 0
 AllowAllAmmo False
 AddAmmo None
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 24000
+//IRL 62USG or 235L
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 16 7 6
 Passengers 7

--- a/run/Flan/Modern Weapons Pack/planes/SU25.txt
+++ b/run/Flan/Modern Weapons Pack/planes/SU25.txt
@@ -60,13 +60,14 @@ ShootPointSecondary 38 28 64 leftWing
 ShootPointSecondary 38 28 -64 rightWing
 
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 2
 BombSlots 0
 MissileSlots 3
 AllowAllAmmo False
 AddAmmo mk4Rocket
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 366000
+//IRL 3660L from 4 internal tanks and 2*840L external aux-tanks
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 79 32 0
 Passengers 0

--- a/run/Flan/Modern Weapons Pack/planes/Tiger.txt
+++ b/run/Flan/Modern Weapons Pack/planes/Tiger.txt
@@ -54,13 +54,14 @@ ShootPointPrimary 27 21 -31 leftWing m60
 ShootPointSecondary 27 21 31 rightWing
 
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 2
 BombSlots 0
 MissileSlots 8
 AllowAllAmmo False
 AddAmmo TRIGAT
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 136000
+//IRL 1360L; No data about aux-tanks
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 53 15 0
 Passengers 1

--- a/run/Flan/Modern Weapons Pack/planes/Tornado.txt
+++ b/run/Flan/Modern Weapons Pack/planes/Tornado.txt
@@ -57,13 +57,14 @@ ShootPointPrimary 60 3 5 nose m60
 ShootPointSecondary -60 16 -58 leftWing
 ShootPointSecondary -60 16 58 rightWing
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 2
 BombSlots 0
 MissileSlots 8
 AllowAllAmmo False
 AddAmmo mk4Rocket
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 150000
+//Thanks to German Wikipedia, IRL 1500L + 750L in aux-tanks.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot -4 20 0
 Passengers 0

--- a/run/Flan/Modern Weapons Pack/vehicles/Abrams.txt
+++ b/run/Flan/Modern Weapons Pack/vehicles/Abrams.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 191000
+//Fuel capacity is oficially 504.4 US gallons, or 1909,3617 liters. Assume that jerry can has 1000 fuel points equal to 10 liters. So capacity will be approximately 1910000. As US Army Government in real life, you will also worry about fuel.
 //Inventory Slots
 CargoSlots 0
 ShellSlots 5

--- a/run/Flan/Modern Weapons Pack/vehicles/ChallyIISimple.txt
+++ b/run/Flan/Modern Weapons Pack/vehicles/ChallyIISimple.txt
@@ -28,9 +28,11 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 160000
+//Officially, fuel capacity is 421 USG or 1593 liters. Converted in to nearest forward value in order to avoid points less than 1000 of gerry can. So it is possible to easily manage number of cans to place into tank.
 //Inventory Slots
-CargoSlots 0
+CargoSlots 5
+//Tanks have some storage inside IRL
 ShellSlots 5
 //Driver and passenger positions
 Driver 0 28 0 -360 360 -10 20

--- a/run/Flan/Modern Weapons Pack/vehicles/Humvee.txt
+++ b/run/Flan/Modern Weapons Pack/vehicles/Humvee.txt
@@ -33,7 +33,8 @@ WheelSpringStrength 0.5
 //If true, then all wheels will apply drive forces
 FourWheelDrive true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 10000
+//IRL fuel capacity is 25USG ar 95L, but it is more convenient to round it to 10000
 //Inventory Slots
 CargoSlots 36
 ShellSlots 0

--- a/run/Flan/Modern Weapons Pack/vehicles/Leopard 2A6.txt
+++ b/run/Flan/Modern Weapons Pack/vehicles/Leopard 2A6.txt
@@ -28,9 +28,10 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 120000
+//317USG or 1200L IRL
 //Inventory Slots
-CargoSlots 0
+CargoSlots 5
 ShellSlots 5
 //Driver and passenger positions
 Driver 0 28 0 -360 360 -9 20

--- a/run/Flan/Modern Weapons Pack/vehicles/MIM23.txt
+++ b/run/Flan/Modern Weapons Pack/vehicles/MIM23.txt
@@ -52,7 +52,8 @@ MissileSlots 3
 AllowAllAmmo False
 AddAmmo mim23Ammo
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 10000
+//It is AA Rocket Launcher, thus, leave it 10000 fuel pts.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Driver 0 6 0 -360 360 0 75
 RotatedDriverOffset 8 0 0

--- a/run/Flan/Modern Weapons Pack/vehicles/T-90.txt
+++ b/run/Flan/Modern Weapons Pack/vehicles/T-90.txt
@@ -28,9 +28,10 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 120000
+//1200L officially without external barrels.
 //Inventory Slots
-CargoSlots 0
+CargoSlots 5
 ShellSlots 5
 //Driver and passenger positions
 Driver 0 20 0 -360 360 -10 20

--- a/run/Flan/WW2 Pack/planes/BF109.txt
+++ b/run/Flan/WW2 Pack/planes/BF109.txt
@@ -64,7 +64,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 40000
+//IRL 400L from 2 tanks.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 9 25 0
 Passengers 0

--- a/run/Flan/WW2 Pack/planes/Camel.txt
+++ b/run/Flan/WW2 Pack/planes/Camel.txt
@@ -61,7 +61,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1500
+FuelTankSize 17000
+//IRL 168L
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 0 -4 0
 Passengers 0

--- a/run/Flan/WW2 Pack/planes/Fokker.txt
+++ b/run/Flan/WW2 Pack/planes/Fokker.txt
@@ -58,7 +58,8 @@ BombSlots 0
 MissileSlots 0
 AllowAllAmmo False
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1500
+FuelTankSize 8000
+//IRL 72L
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 0 -4 0
 Passengers 0

--- a/run/Flan/WW2 Pack/planes/Lancaster.txt
+++ b/run/Flan/WW2 Pack/planes/Lancaster.txt
@@ -61,7 +61,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 32000
+FuelTankSize 800000
+//IRL ranging from 7779L to 9792L, so let it be 8000L
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 115 20 0
 Passengers 5

--- a/run/Flan/WW2 Pack/planes/Mustang.txt
+++ b/run/Flan/WW2 Pack/planes/Mustang.txt
@@ -68,7 +68,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 4000
+FuelTankSize 10000
+//IRL 348x2L+322L internal tanks. Let it be 1000L generally.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 9 23 0
 Passengers 0

--- a/run/Flan/WW2 Pack/planes/Spitfire.txt
+++ b/run/Flan/WW2 Pack/planes/Spitfire.txt
@@ -54,7 +54,7 @@ ShootPointPrimary 40 -4 -44 leftWing browning
 ShootPointSecondary -30 -12 0
 DamageModifierPrimary 50
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 1
 BombSlots 4
 MissileSlots 0
 AllowAllAmmo False
@@ -62,7 +62,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 5000
+FuelTankSize 39000
+//IRL upper 168L tank and lower 218L tank + one of 135/205/228/410/775L aux-tanks on hold.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot -4 -4 0
 Passengers 0

--- a/run/Flan/WW2 Pack/planes/Yak9.txt
+++ b/run/Flan/WW2 Pack/planes/Yak9.txt
@@ -54,7 +54,7 @@ ShootPointPrimary 60 3 -5 nose dp28
 ShootPointSecondary -30 -12 0
 DamageModifierPrimary 50
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 2
 BombSlots 3
 MissileSlots 0
 AllowAllAmmo False
@@ -62,7 +62,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 43000
+//430L volume of tanks may be obtained by doing some math+physics with 322kg of benzin. Yak-9 original(no D, T or other letter) carried 322kg of fuel.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 12 4 0
 Passengers 0

--- a/run/Flan/WW2 Pack/planes/Zero.txt
+++ b/run/Flan/WW2 Pack/planes/Zero.txt
@@ -54,7 +54,7 @@ ShootPointPrimary 80 11 -6 nose type99
 ShootPointSecondary -30 -22 0
 DamageModifierPrimary 50
 // ------------------------------------------------------ Inventory ------------------------------------------------------
-CargoSlots 0
+CargoSlots 2
 BombSlots 3
 MissileSlots 0
 AllowAllAmmo False
@@ -62,7 +62,8 @@ AddAmmo largeBomb
 AddAmmo smallBomb
 AddAmmo napalm
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 6000
+FuelTankSize 52000
+//IRL 518L or 137USG
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 10 2 0
 Passengers 0

--- a/run/Flan/WW2 Pack/vehicles/B1.txt
+++ b/run/Flan/WW2 Pack/vehicles/B1.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 40000
+//400L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/BMWR75.txt
+++ b/run/Flan/WW2 Pack/vehicles/BMWR75.txt
@@ -33,7 +33,8 @@ WheelSpringStrength 0.5
 //If true, then all wheels will apply drive forces
 FourWheelDrive false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 10000
+//IRL from 24 to 42 and 102L
 //Inventory Slots
 CargoSlots 36
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/Chaffee.txt
+++ b/run/Flan/WW2 Pack/vehicles/Chaffee.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 42000
+//IRL 110USG or 420L
 //Inventory Slots
 CargoSlots 10
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Chi-Ha.txt
+++ b/run/Flan/WW2 Pack/vehicles/Chi-Ha.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 24000
+//IRL 235L
 //Inventory Slots
 CargoSlots 0
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/ChiNu.txt
+++ b/run/Flan/WW2 Pack/vehicles/ChiNu.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 24000
+//235L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Churchill.txt
+++ b/run/Flan/WW2 Pack/vehicles/Churchill.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 83000
+//682L+148L(aux-tank inside)
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Cromwell.txt
+++ b/run/Flan/WW2 Pack/vehicles/Cromwell.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 50000
+//IRL 110IG+aux 30IG; so 500L
 //Inventory Slots
 CargoSlots 10
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Crusader.txt
+++ b/run/Flan/WW2 Pack/vehicles/Crusader.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 50000
+//110IG + 30IG aux; so 500L
 //Inventory Slots
 CargoSlots 10
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Flak88.txt
+++ b/run/Flan/WW2 Pack/vehicles/Flak88.txt
@@ -26,7 +26,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 4000
+//This gun was on just simple cart, but imagine that it was motorred in minecraft.
 //Inventory Slots
 CargoSlots 0
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Fury.txt
+++ b/run/Flan/WW2 Pack/vehicles/Fury.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 60000
+//138–175 U.S. gallons (522–662 litres),so 600L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Greyhound.txt
+++ b/run/Flan/WW2 Pack/vehicles/Greyhound.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 21000
+//IRL 56USG or 210L
 //Inventory Slots
 CargoSlots 10
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Hellcat.txt
+++ b/run/Flan/WW2 Pack/vehicles/Hellcat.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 29000
+//75USG or 284L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/IS2.txt
+++ b/run/Flan/WW2 Pack/vehicles/IS2.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 52000
+//520L IRL without 270L of aux-tanks
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Jeep.txt
+++ b/run/Flan/WW2 Pack/vehicles/Jeep.txt
@@ -33,7 +33,8 @@ WheelSpringStrength 0.5
 //If true, then all wheels will apply drive forces
 FourWheelDrive true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 7000
+//57L IRL
 //Inventory Slots
 CargoSlots 36
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/KV1.txt
+++ b/run/Flan/WW2 Pack/vehicles/KV1.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 61000
+//IRL-600-615L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Kubel.txt
+++ b/run/Flan/WW2 Pack/vehicles/Kubel.txt
@@ -33,7 +33,8 @@ WheelSpringStrength 0.5
 //If true, then all wheels will apply drive forces
 FourWheelDrive false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 10000
+//No data about IRL FC, so let it be 100L
 //Inventory Slots
 CargoSlots 36
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/Luchs.txt
+++ b/run/Flan/WW2 Pack/vehicles/Luchs.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 29000
+//285L IRL
 //Inventory Slots
 CargoSlots 10
 ShellSlots 1

--- a/run/Flan/WW2 Pack/vehicles/M10.txt
+++ b/run/Flan/WW2 Pack/vehicles/M10.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 62000
+//IRL 620L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/M157mm.txt
+++ b/run/Flan/WW2 Pack/vehicles/M157mm.txt
@@ -26,7 +26,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 3000
+//Its gun, not tank. Leave it 30L
 //Inventory Slots
 CargoSlots 0
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/M3Halftrack.txt
+++ b/run/Flan/WW2 Pack/vehicles/M3Halftrack.txt
@@ -30,7 +30,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 23000
+//230L or 62USG IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/PanzerIV.txt
+++ b/run/Flan/WW2 Pack/vehicles/PanzerIV.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 47000
+//470L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/S100.txt
+++ b/run/Flan/WW2 Pack/vehicles/S100.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 20000
+//No Data on IRL FC, but 200L diesel looks ok.
 //Inventory Slots
 CargoSlots 10
 ShellSlots 2

--- a/run/Flan/WW2 Pack/vehicles/SASJeep.txt
+++ b/run/Flan/WW2 Pack/vehicles/SASJeep.txt
@@ -33,7 +33,8 @@ WheelSpringStrength 0.5
 //If true, then all wheels will apply drive forces
 FourWheelDrive true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 10000
+//100L
 //Inventory Slots
 CargoSlots 36
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/SU-1-12.txt
+++ b/run/Flan/WW2 Pack/vehicles/SU-1-12.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 10000
+//IRL it had 40L tank on GasAAA car.
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/SdkFz2.txt
+++ b/run/Flan/WW2 Pack/vehicles/SdkFz2.txt
@@ -35,7 +35,8 @@ FourWheelDrive false
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 36000
+//360L IRL
 //Inventory Slots
 CargoSlots 36
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/SdkFz222.txt
+++ b/run/Flan/WW2 Pack/vehicles/SdkFz222.txt
@@ -30,7 +30,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 10000
+//German Wikipedia 100L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/SdkFz251.txt
+++ b/run/Flan/WW2 Pack/vehicles/SdkFz251.txt
@@ -30,7 +30,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 16000
+//German wikipedia 160L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 0

--- a/run/Flan/WW2 Pack/vehicles/Sherman.txt
+++ b/run/Flan/WW2 Pack/vehicles/Sherman.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 60000
+//600L because IRL it oscillated between 522-662L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/StuG.txt
+++ b/run/Flan/WW2 Pack/vehicles/StuG.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 43000
+//430L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/T3485.txt
+++ b/run/Flan/WW2 Pack/vehicles/T3485.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 81000
+//810L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Tiger.txt
+++ b/run/Flan/WW2 Pack/vehicles/Tiger.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 54000
+//IRL Tiger I had 540L and Tiger II had 860L
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Tiger131.txt
+++ b/run/Flan/WW2 Pack/vehicles/Tiger131.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 54000
+//IRL it was captured TigerI tank with 540L.
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/TigerII.txt
+++ b/run/Flan/WW2 Pack/vehicles/TigerII.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 86000
+//Tiger II had 860L IRL
 //Inventory Slots
 CargoSlots 20
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/Type4HoRo.txt
+++ b/run/Flan/WW2 Pack/vehicles/Type4HoRo.txt
@@ -28,7 +28,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank true
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 24000
+//IRL had 235L diesel tank.
 //Inventory Slots
 CargoSlots 0
 ShellSlots 5

--- a/run/Flan/WW2 Pack/vehicles/UC2Pdr.txt
+++ b/run/Flan/WW2 Pack/vehicles/UC2Pdr.txt
@@ -29,7 +29,8 @@ FourWheelDrive true
 //Tank mode activate
 Tank false
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 2000
+FuelTankSize 10000
+//IRL had 91L or 20IG
 //Inventory Slots
 CargoSlots 10
 //Driver and passenger positions

--- a/run/Flan/Ye Olde Pack/planes/Biplane.txt
+++ b/run/Flan/Ye Olde Pack/planes/Biplane.txt
@@ -55,7 +55,8 @@ BombSlots 0
 MissileSlots 0
 AllowAllAmmo False
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1000
+FuelTankSize 15000
+//Increased size due to #1270 fix. No IRL equivalents.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 0 -4 0
 Passengers 0

--- a/run/Flan/Ye Olde Pack/planes/TwoSeatBiplane.txt
+++ b/run/Flan/Ye Olde Pack/planes/TwoSeatBiplane.txt
@@ -55,7 +55,8 @@ BombSlots 0
 MissileSlots 0
 AllowAllAmmo False
 //Fuel Tank Size (1 point of fuel will keep one propeller going with throttle at 1 for 1 tick)
-FuelTankSize 1500
+FuelTankSize 17000
+//No IRL equivalents, so let it be 170L.
 // ------------------------------------------------------ Passengers ------------------------------------------------------
 Pilot 0 -4 0
 Passengers 1


### PR DESCRIPTION
Spent 5 hours fixing #1270 issue, used real fuel capacities. Hope it will really help players with that issue. This fix also gives a true reason for players to dig the coal. There is trouble, though: if, for example, buggy may be filled in 4-5 mins, the B-52 bomber will take much more time(181275L of fuel or 18200000 points). It would be fixed by introducing fuel barrels and changing fuel uploading speed. Also Engines need to be managed. V4 V6 V8 and Rotary one. I don't know how to update their capabilities to match metric  system. Better leave them as they are now.