### PR TITLE
Only load files that actually end on .jar or .zip

### DIFF
--- a/src/main/java/com/flansmod/common/CommonProxy.java
+++ b/src/main/java/com/flansmod/common/CommonProxy.java
@@ -41,7 +41,7 @@ import com.google.common.io.Files;
 
 public class CommonProxy
 {
-	protected static Pattern zipJar = Pattern.compile("(.+).(zip|jar)$");
+	protected static Pattern zipJar = Pattern.compile("(.+)\.(zip|jar)$");
 	
 	public void LoadAssetsFromFlanFolder()
 	{

--- a/src/main/java/com/flansmod/common/CommonProxy.java
+++ b/src/main/java/com/flansmod/common/CommonProxy.java
@@ -41,7 +41,7 @@ import com.google.common.io.Files;
 
 public class CommonProxy
 {
-	protected static Pattern zipJar = Pattern.compile("(.+)\.(zip|jar)$");
+	protected static Pattern zipJar = Pattern.compile("(.+)\\.(zip|jar)$");
 	
 	public void LoadAssetsFromFlanFolder()
 	{

--- a/src/main/java/com/flansmod/common/ContentManager.java
+++ b/src/main/java/com/flansmod/common/ContentManager.java
@@ -94,7 +94,7 @@ public class ContentManager
 	}
 	
 	private HashMap<String, IFlansModContentProvider> packs = new HashMap<String, IFlansModContentProvider>();
-	protected Pattern zipJar = Pattern.compile("(.+).(zip|jar)$");
+	protected Pattern zipJar = Pattern.compile("(.+)\.(zip|jar)$");
 	private boolean wasAnythingInFlanFolder = false;
 	
 	public boolean LoadedAnyContentFromFlanFolder()

--- a/src/main/java/com/flansmod/common/ContentManager.java
+++ b/src/main/java/com/flansmod/common/ContentManager.java
@@ -94,7 +94,7 @@ public class ContentManager
 	}
 	
 	private HashMap<String, IFlansModContentProvider> packs = new HashMap<String, IFlansModContentProvider>();
-	protected Pattern zipJar = Pattern.compile("(.+)\.(zip|jar)$");
+	protected Pattern zipJar = Pattern.compile("(.+)\\.(zip|jar)$");
 	private boolean wasAnythingInFlanFolder = false;
 	
 	public boolean LoadedAnyContentFromFlanFolder()


### PR DESCRIPTION
The '.' character in a regex matches everything and should be escaped