### PR TITLE
Fixed issue where gun tables took infinite materials

### DIFF
--- a/src/main/java/com/flansmod/common/guns/boxes/GunBoxType.java
+++ b/src/main/java/com/flansmod/common/guns/boxes/GunBoxType.java
@@ -317,8 +317,9 @@ public class GunBoxType extends BoxType
 		
 		private boolean haveEnoughOf(InventoryPlayer temporaryInventory, ItemStack stackNeeded, boolean takeItems)
 		{
-			//The total amount of items found that match this recipe stack
-			int totalAmountFound = 0;
+			//Initialize the amount of items we will need
+			int amountNeeded = stackNeeded.getCount();
+			
 			//Iterate over the temporary inventory
 			for(int m = 0; m < temporaryInventory.getSizeInventory(); m++)
 			{
@@ -327,23 +328,23 @@ public class GunBoxType extends BoxType
 				//If the stack is what we want
 				if(stackInSlot.getItem() == stackNeeded.getItem() && stackInSlot.getItemDamage() == stackNeeded.getItemDamage())
 				{
-					//Work out the amount to take from the stack
-					int amountFound = Math.min(stackInSlot.getCount(), stackNeeded.getCount() - totalAmountFound);
-					//Take it
-					stackInSlot.setCount(stackInSlot.getCount() - amountFound);
-					//Check for empty stacks
-					if(stackInSlot.getCount() <= 0)
-						stackInSlot = ItemStack.EMPTY.copy();
-					//Put the modified stack back in the inventory
-					temporaryInventory.setInventorySlotContents(m, stackInSlot);
-					//Increase the amount found counter
-					totalAmountFound += amountFound;
-					//If we have enough, stop looking
-					if(totalAmountFound == stackNeeded.getCount())
+					//Check if the the remaining amount needed is less than the current stack
+					if (stackInSlot.getCount() < amountNeeded) {
+						//If the current stack is less than we need
+						//consume the whole stack and reduce the remaining amount needed by the stack size
+						amountNeeded -= stackInSlot.getCount();
+						stackInSlot.setCount(0);
+					} else {
+						//If the current stack is more than we need
+						//set the remaining amount needed to 0 and reduce the stack by the amount we take
+						amountNeeded = 0;
+						stackInSlot.setCount(stackInSlot.getCount() - amountNeeded);
 						break;
+					}
 				}
 			}
-			return totalAmountFound >= stackNeeded.getCount();
+			//Ensure that we have reached enough materials
+			return amountNeeded == 0;
 		}
 		
 		public boolean canCraft(InventoryPlayer inv, boolean takeItems)


### PR DESCRIPTION
Fix for #1345

## Issue
When attempting to create weapons on content pack gun boxes, the box would take the whole inventory of the first material. The recipe would then be incomplete and the gun could not be created

## Problem:
In the method that checks if a `GunBoxEntry` is satisfied, there was a method that consumed all stacks. While iterating over the inventory, entire stacks were consumed with no checks to terminate if the amount. 

## Solution:
Reworked how this method functions, by starting with the amount needed and subtracting the stack's amounts from this value until its zero.

## Tests:
Tested on MC 1.12.2 with no other mods. Tested with multiple stack sizes, valid and invalid.