### PR TITLE
Balance fuel consumption

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntityPlane.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityPlane.java
@@ -466,8 +466,6 @@ public class EntityPlane extends EntityDriveable
 		int numPropsWorking = 0;
 		int numProps = 0;
 		
-		float fuelConsumptionMultiplier = 2F;
-		
 		switch(mode)
 		{
 			case HELI:
@@ -509,7 +507,7 @@ public class EntityPlane extends EntityDriveable
 				motionY *= drag;
 				motionZ *= drag;
 				
-				data.fuelInTank -= upwardsForce * fuelConsumptionMultiplier * data.engine.fuelConsumption;
+				data.fuelInTank -= upwardsForce * data.engine.fuelConsumption * 2F;
 				
 				break;
 			
@@ -571,7 +569,7 @@ public class EntityPlane extends EntityDriveable
 				motionY *= drag;
 				motionZ *= drag;
 				
-				data.fuelInTank -= throttleScaled * fuelConsumptionMultiplier * data.engine.fuelConsumption;
+				data.fuelInTank -= Math.abs(throttle) * throttleScaled * data.engine.fuelConsumption * 10F;
 				break;
 			default:
 				break;

--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -390,7 +390,7 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable
 			{
 				if (!driverIsCreative())
 				{
-					data.fuelInTank -= data.engine.fuelConsumption * Math.abs(throttle);
+					data.fuelInTank -= data.engine.fuelConsumption * Math.abs(throttle) * 0.05F;
 				}
 
 				if(getVehicleType().tank)

--- a/src/main/java/com/flansmod/common/driveables/mechas/EntityMecha.java
+++ b/src/main/java/com/flansmod/common/driveables/mechas/EntityMecha.java
@@ -639,7 +639,7 @@ public class EntityMecha extends EntityDriveable
 
 					//If we can't thrust creatively, we must thrust using fuel. Nom.
 					if(!isCreative)
-						data.fuelInTank -= data.engine.fuelConsumption;
+						data.fuelInTank -= data.engine.fuelConsumption * 0.5F;
 				}
 			}
 


### PR DESCRIPTION
fixes #1270 

- Fixed vehicles consuming way too much fuel.
- Reduced fuel consumption of mechas and increased consumption of planes.
- Fixed planes consuming fuel as if they were going max speed when standing still.