### PR TITLE
Prevent editors from removing trailing whitespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = tab
+trim_trailing_whitespace = false
 
 [*.java]
 insert_final_newline = true


### PR DESCRIPTION
Specify in the .editorconfig to not delete trailing whitespaces because in many editors, like IntelliJ it's the default to delete them and
- It is the de facto standard in the project that empty lines are also indented
- In content pack files, trailing whitespaces are necessary in crafting recipes